### PR TITLE
Introduce user defined and fuzzy comparators

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,5 @@
+---
+include:
+  - project: 'BI/bdap-2.0/common-libraries/cicd-commons'
+    ref: live
+    file: 'nexusDeployTemplates/mavenDeployTemplates/maven-deploy-template.yml'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,0 @@
----
-include:
-  - project: 'BI/bdap-2.0/common-libraries/cicd-commons'
-    ref: live
-    file: 'nexusDeployTemplates/mavenDeployTemplates/maven-deploy-template.yml'

--- a/pom.xml
+++ b/pom.xml
@@ -144,4 +144,19 @@
       </plugin>
     </plugins>
   </build>
+
+  <distributionManagement>
+    <repository>
+      <id>datalake-releases-gcp-deploy</id>
+      <name>Tchibo GmbH (BI) Internal Repository</name>
+      <url>${repo.host}/repository/maven-releases/</url>
+    </repository>
+
+    <snapshotRepository>
+      <id>datalake-snapshots-gcp-deploy</id>
+      <name>Tchibo GmbH (BI) Internal Snapshot Repository</name>
+      <url>${repo.host}/repository/maven-snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,8 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.co.gresearch.spark</groupId>
   <artifactId>spark-extension</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
-
-  <name>Spark Extension</name>
+  <version>1.0.0-SNAPSHOT</version>
+  <name>${project.artifactId}</name>
   <description>A library that provides useful extensions to Apache Spark.</description>
   <inceptionYear>2020</inceptionYear>
   <url>https://github.com/G-Research</url>
@@ -33,13 +32,12 @@
   </issueManagement>
 
   <properties>
-    <java.version>1.8</java.version>
-    <maven.compiler.source>${java.version}</maven.compiler.source>
-    <maven.compiler.target>${java.version}</maven.compiler.target>
+    <maven.compiler.source>1.5</maven.compiler.source>
+    <maven.compiler.target>1.5</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <scala.version>2.11.11</scala.version>
-    <scala.binary.version>2.11</scala.binary.version>
-    <spark.version>2.4.4</spark.version>
+    <scala.version.major>2.12</scala.version.major>
+    <scala.version>${scala.version.major}.10</scala.version>
+    <spark.version>2.4.5</spark.version>
   </properties>
 
   <dependencies>
@@ -51,14 +49,14 @@
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <artifactId>spark-core_${scala.version.major}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <artifactId>spark-sql_${scala.version.major}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -66,7 +64,7 @@
     <!-- Test -->
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
+      <artifactId>spark-catalyst_${scala.version.major}</artifactId>
       <version>${spark.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -74,11 +72,18 @@
 
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_${scala.binary.version}</artifactId>
+      <artifactId>scalatest_${scala.version.major}</artifactId>
       <version>3.0.8</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
 
   <build>
     <sourceDirectory>src/main/scala</sourceDirectory>
@@ -117,6 +122,31 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.8</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>false</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.5</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>2.2.1</version>
@@ -144,19 +174,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <distributionManagement>
-    <repository>
-      <id>datalake-releases-gcp-deploy</id>
-      <name>Tchibo GmbH (BI) Internal Repository</name>
-      <url>${repo.host}/repository/maven-releases/</url>
-    </repository>
-
-    <snapshotRepository>
-      <id>datalake-snapshots-gcp-deploy</id>
-      <name>Tchibo GmbH (BI) Internal Snapshot Repository</name>
-      <url>${repo.host}/repository/maven-snapshots/</url>
-    </snapshotRepository>
-  </distributionManagement>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -117,17 +117,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>false</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>2.2.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,9 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <scala.version>2.12.10</scala.version>
-    <scala.binary.version>2.12</scala.binary.version>
-    <spark.version>2.4.5</spark.version>
+    <scala.version>2.11.11</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
+    <spark.version>2.4.4</spark.version>
   </properties>
 
   <dependencies>
@@ -132,20 +132,6 @@
           <nexusUrl>https://oss.sonatype.org/</nexusUrl>
           <autoReleaseAfterClose>false</autoReleaseAfterClose>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.5</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.co.gresearch.spark</groupId>
-  <artifactId>spark-extension_${scala.binary.version}</artifactId>
+  <artifactId>spark-extension</artifactId>
   <version>1.1.0-SNAPSHOT</version>
 
   <name>Spark Extension</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,7 @@
   <groupId>uk.co.gresearch.spark</groupId>
   <artifactId>spark-extension_${scala.binary.version}</artifactId>
   <version>1.1.0-SNAPSHOT</version>
+
   <name>Spark Extension</name>
   <description>A library that provides useful extensions to Apache Spark.</description>
   <inceptionYear>2020</inceptionYear>
@@ -78,13 +79,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
 
   <build>
     <sourceDirectory>src/main/scala</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.co.gresearch.spark</groupId>
-  <artifactId>spark-extension</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
-  <name>${project.artifactId}</name>
+  <artifactId>spark-extension_${scala.binary.version}</artifactId>
+  <version>1.1.0-SNAPSHOT</version>
+  <name>Spark Extension</name>
   <description>A library that provides useful extensions to Apache Spark.</description>
   <inceptionYear>2020</inceptionYear>
   <url>https://github.com/G-Research</url>
@@ -32,11 +32,12 @@
   </issueManagement>
 
   <properties>
-    <maven.compiler.source>1.5</maven.compiler.source>
-    <maven.compiler.target>1.5</maven.compiler.target>
+    <java.version>1.8</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <scala.version.major>2.12</scala.version.major>
-    <scala.version>${scala.version.major}.10</scala.version>
+    <scala.version>2.12.10</scala.version>
+    <scala.binary.version>2.12</scala.binary.version>
     <spark.version>2.4.5</spark.version>
   </properties>
 
@@ -49,14 +50,14 @@
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.version.major}</artifactId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_${scala.version.major}</artifactId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -64,7 +65,7 @@
     <!-- Test -->
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-catalyst_${scala.version.major}</artifactId>
+      <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -72,7 +73,7 @@
 
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_${scala.version.major}</artifactId>
+      <artifactId>scalatest_${scala.binary.version}</artifactId>
       <version>3.0.8</version>
       <scope>test</scope>
     </dependency>

--- a/src/main/scala/uk/co/gresearch/spark/diff/Diff.scala
+++ b/src/main/scala/uk/co/gresearch/spark/diff/Diff.scala
@@ -91,8 +91,9 @@ class Diff(options: DiffOptions) {
     val existsColumnName = Diff.distinctStringNameFor(left.columns)
     val l = left.withColumn(existsColumnName, lit(1))
     val r = right.withColumn(existsColumnName, lit(1))
-    val joinCondition = pkColumns.map(c => l(c) <=> r(c)).reduce(_ && _)
-    val unChanged = otherColumns.map(c => l(c) <=> r(c)).reduceOption(_ && _)
+
+    val joinCondition = pkColumns.map(c => options.getDiffComparator(c).compareColumns(l(c), r(c))).reduce(_ && _)
+    val unChanged = otherColumns.map(c => options.getDiffComparator(c).compareColumns(l(c), r(c))).reduceOption(_ && _)
     val changeCondition = not(unChanged.getOrElse(lit(true)))
 
     val diffCondition =

--- a/src/main/scala/uk/co/gresearch/spark/diff/DiffComparator.scala
+++ b/src/main/scala/uk/co/gresearch/spark/diff/DiffComparator.scala
@@ -41,7 +41,8 @@ object DiffComparator{
     assert(divergence >= significantDigitAddon, "The divergence parameter hast to be greater or equal to " + significantDigitAddon + " for datatype " + datatype)
     override def description: String = "Compares two numbers and considers them equal as long as their difference is below the given divergence."
     override def compare(left: Column, right: Column): Expression = {
-      LessThanOrEqual(abs(left - right).expr, lit(divergence + significantDigitAddon).expr)
+      Or(And(IsNull(left.expr), IsNull(right.expr)),
+      LessThanOrEqual(abs(left - right).expr, lit(divergence + significantDigitAddon).expr))
     }
   }
 
@@ -79,7 +80,8 @@ object DiffComparator{
         UnixTimestamp(rightTimestamp.expr, defaultUnixFormat, Some(rightTz.getID))
       ))
 
-      (diffInSeconds > lit(0) && diffInSeconds <= lit(leftBeforeRight) ||
+      ( leftTimestamp.isNull && rightTimestamp.isNull ||
+        diffInSeconds > lit(0) && diffInSeconds <= lit(leftBeforeRight) ||
         diffInSeconds <= lit(0) && abs(diffInSeconds) <= lit(leftAfterRight)).expr
     }
 }

--- a/src/main/scala/uk/co/gresearch/spark/diff/DiffComparator.scala
+++ b/src/main/scala/uk/co/gresearch/spark/diff/DiffComparator.scala
@@ -1,0 +1,116 @@
+package uk.co.gresearch.spark.diff
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.catalyst.util.DateTimeUtils._
+import org.apache.spark.sql.types.{DataType, DoubleType, FloatType}
+
+/**
+ * Abstract class for a Comparator factory of a given comparison type.
+ * @param symbols - list of symbols referencing the given comparison method
+ */
+abstract class DiffComparator(val symbols: Seq[String]) {
+  
+  def description: String
+
+  /**
+   * The Compare Expression of two other expressions (usually resolved as instance of [[BinaryExpression]]
+   * @param left - the left expression of a binary expression (left Column)
+   * @param right - the right expression of a binary expression (right Column)
+   */
+  def compare(left: Column, right: Column): Expression
+
+  /**
+   * The same as expression based compare function but based on left Column compared to right Column
+   * @param left - left Column
+   * @param right - right Column
+   */
+  def compareColumns(left: Column, right: Column): Column = new Column(compare(left, right))
+}
+
+object DiffComparator{
+
+  case class FuzzyNumberComparator(divergence: Double, datatype: DataType = FloatType) extends DiffComparator(Seq("~~")) {
+    // we add a bit more divergence to compensate oscillating differences at the end of the precision range
+    private val significantDigitAddon = datatype match{
+      case FloatType => 0.000001              // floats has 6 significant digits
+      case DoubleType => 0.0000000000000001   // double has 16 significant digits
+      case _ => 0                             // otherwise integer numbers...
+    }
+    assert(divergence >= significantDigitAddon, "The divergence parameter hast to be greater or equal to " + significantDigitAddon + " for datatype " + datatype)
+    override def description: String = "Compares two numbers and considers them equal as long as their difference is below the given divergence."
+    override def compare(left: Column, right: Column): Expression = {
+      LessThanOrEqual(abs(left - right).expr, lit(divergence + significantDigitAddon).expr)
+    }
+  }
+
+  /**
+   * Fuzzy timestamp comparator allowing for a grace duration before and after the right column values
+   * @param leftBeforeRight - number of seconds before the right timestamp in which the left timestamp may occur to be considered equal
+   * @param leftAfterRight - number of seconds after the right timestamp in which the left timestamp may occur to be considered equal
+   * @param leftTimeZone - the time zone of the left column (by default: UTC)
+   * @param rightTimeZone - the time zone of the left column (by default: UTC)
+   */
+  case class FuzzyDateComparator(
+    leftBeforeRight: Int,
+    leftAfterRight: Int,
+    leftTimeZone: String = "UTC",
+    rightTimeZone: String = "UTC"
+  ) extends DiffComparator(Seq[String]()){
+    assert(leftBeforeRight >= 0 && leftAfterRight >= 0, "Durations below one second are not allowed for FuzzyDateComparator.")
+    override def description: String = "For comparing two timestamps allowing for a given diversion before and after "
+
+    private val defaultUnixFormat = Literal("yyyy-MM-dd HH:mm:ss") // is actually not used
+    private val leftTz = Option(getTimeZone(leftTimeZone)).getOrElse(throw new IllegalArgumentException("Invalid time zone: " + leftTimeZone))
+    private val rightTz = Option(getTimeZone(rightTimeZone)).getOrElse(throw new IllegalArgumentException("Invalid time zone: " + rightTimeZone))
+
+    /**
+     * The Compare Expression of two other expressions (usually resolved as instance of [[BinaryExpression]]
+     *
+     * @param left  - the left expression of a binary expression (left Column)
+     * @param right - the right expression of a binary expression (right Column)
+     */
+    override def compare(left: Column, right: Column): Expression = {
+      val leftTimestamp = to_utc_timestamp(left, leftTz.getID)
+      val rightTimestamp = to_utc_timestamp(right, rightTz.getID)
+      val diffInSeconds = new Column(Subtract(
+        UnixTimestamp(leftTimestamp.expr, defaultUnixFormat, Some(leftTz.getID)),
+        UnixTimestamp(rightTimestamp.expr, defaultUnixFormat, Some(rightTz.getID))
+      ))
+
+      (diffInSeconds > lit(0) && diffInSeconds <= lit(leftBeforeRight) ||
+        diffInSeconds <= lit(0) && abs(diffInSeconds) <= lit(leftAfterRight)).expr
+    }
+}
+
+  // this is the default comparator
+  val EqualNullSafeComparator: DiffComparator = new DiffComparator(Seq("<=>", "eqNullSafe")){
+      override def compare(left: Column, right: Column): Expression = EqualNullSafe(left.expr, right.expr)
+      override def description: String = "equality comparator which is null safe"
+    }
+  val EqualToComparator: DiffComparator = new DiffComparator(Seq("=", "===", "eq", "equalTo")){
+      override def compare(left: Column, right: Column): Expression = EqualTo(left.expr, right.expr)
+      override def description: String = "equals comparator"
+    }
+  val NotEqualToComparator: DiffComparator = new DiffComparator(Seq("=!=", "!==", "notEqual")){
+      override def compare(left: Column, right: Column): Expression = Not(EqualTo(left.expr, right.expr))
+      override def description: String = "not equals comparator"
+    }
+  val GreaterThanComparator: DiffComparator = new DiffComparator(Seq(">", "gt")){
+      override def compare(left: Column, right: Column): Expression = GreaterThan(left.expr, right.expr)
+      override def description: String = "greater than comparator"
+    }
+  val LessThanComparator: DiffComparator = new DiffComparator(Seq("<", "lt")){
+      override def compare(left: Column, right: Column): Expression = LessThan(left.expr, right.expr)
+      override def description: String = "less than comparator"
+    }
+  val GreaterThanOrEqualComparator: DiffComparator = new DiffComparator(Seq(">=", "geq")){
+      override def compare(left: Column, right: Column): Expression = GreaterThanOrEqual(left.expr, right.expr)
+      override def description: String = "greater than or equals comparator"
+    }
+  val LessThanOrEqualComparator: DiffComparator = new DiffComparator(Seq("<=", "leq")){
+      override def compare(left: Column, right: Column): Expression = LessThanOrEqual(left.expr, right.expr)
+      override def description: String = "less than or equals comparator"
+    }
+}

--- a/src/main/scala/uk/co/gresearch/spark/diff/DiffOptions.scala
+++ b/src/main/scala/uk/co/gresearch/spark/diff/DiffOptions.scala
@@ -37,6 +37,8 @@ case class DiffOptions(
   changeDiffValue: String,
   deleteDiffValue: String,
   nochangeDiffValue: String,
+  changedColumnIndicator: Option[String] = Some("changedColumn"),
+  ignoreColumns: Seq[String] = Seq(),
   specialComparators: Map[String, DiffComparator] = Map()
 ) {
 
@@ -130,5 +132,5 @@ object DiffOptions {
   /**
    * Default diffing options.
    */
-  val default: DiffOptions = DiffOptions("diff", "left", "right", "I", "C", "D", "N")
+  val default: DiffOptions = DiffOptions("diff", "left", "right", "I", "C", "D", "N", None)
 }

--- a/src/main/scala/uk/co/gresearch/spark/diff/DiffOptions.scala
+++ b/src/main/scala/uk/co/gresearch/spark/diff/DiffOptions.scala
@@ -27,19 +27,29 @@ package uk.co.gresearch.spark.diff
  * @param changeDiffValue value in diff column for changed rows
  * @param deleteDiffValue value in diff column for deleted rows
  * @param nochangeDiffValue value in diff column for un-changed rows
+ * @param specialComparators an optional map of column names with the applicable comparator, overwriting the default '<=>' comparator
  */
-case class DiffOptions(diffColumn: String,
-                       leftColumnPrefix: String,
-                       rightColumnPrefix: String,
-                       insertDiffValue: String,
-                       changeDiffValue: String,
-                       deleteDiffValue: String,
-                       nochangeDiffValue: String) {
+case class DiffOptions(
+  diffColumn: String,
+  leftColumnPrefix: String,
+  rightColumnPrefix: String,
+  insertDiffValue: String,
+  changeDiffValue: String,
+  deleteDiffValue: String,
+  nochangeDiffValue: String,
+  specialComparators: Map[String, DiffComparator] = Map()
+) {
 
   require(leftColumnPrefix.nonEmpty, "Left column prefix must not be empty")
   require(rightColumnPrefix.nonEmpty, "Right column prefix must not be empty")
+
   require(leftColumnPrefix != rightColumnPrefix,
     s"Left and right column prefix must be distinct: $leftColumnPrefix")
+
+  /**
+   * Returns the applicable comparator for the given column
+   */
+  def getDiffComparator(columnName: String): DiffComparator = specialComparators.getOrElse(columnName, DiffComparator.EqualNullSafeComparator)
 
   val diffValues = Seq(insertDiffValue, changeDiffValue, deleteDiffValue, nochangeDiffValue)
   require(diffValues.distinct.length == diffValues.length,

--- a/src/main/scala/uk/co/gresearch/spark/diff/DiffOptions.scala
+++ b/src/main/scala/uk/co/gresearch/spark/diff/DiffOptions.scala
@@ -36,6 +36,9 @@ import org.apache.spark.sql.types.{DataType, StructField}
  * @param ignoreColumns an optional list of columns which are dropped from both sides before comparing
  * @param datatypeComparators an optional map of datatypes with the applicable comparator, overwriting the default '<=>' comparator
  * @param columnComparators an optional map of column names with the applicable comparator, overwriting the datatype comparators
+ * @param joinType  Type of the join to perform. Default `full_outer`, should usually not be changed.
+ *                  Only in some cases advisable, such as for testing purposes to avoid OOM exceptions or to zero in on a specific section of the diff.
+ *                  Must be one of: `inner`, `cross`, `outer`, `full`, `full_outer`, `left`, `left_outer`, `right`, `right_outer`, `left_semi`, `left_anti`.
  */
 case class DiffOptions(
   diffColumn: String,
@@ -48,7 +51,8 @@ case class DiffOptions(
   nullOutValidData: Boolean = false,
   ignoreColumns: Seq[String] = Seq(),
   datatypeComparators: Map[DataType, DiffComparator] = Map(),
-  columnComparators: Map[String, DiffComparator] = Map()
+  columnComparators: Map[String, DiffComparator] = Map(),
+  joinType: String = "full_outer"
 ) {
 
   require(leftColumnPrefix.nonEmpty, "Left column prefix must not be empty")

--- a/src/main/scala/uk/co/gresearch/spark/diff/package.scala
+++ b/src/main/scala/uk/co/gresearch/spark/diff/package.scala
@@ -147,7 +147,7 @@ package object diff {
      */
     @scala.annotation.varargs
     def diffAs[U](other: Dataset[T], diffEncoder: Encoder[U], idColumns: String*): Dataset[U] = {
-      Diff.ofAs(this.ds, other, diffEncoder, idColumns: _*)
+      Diff.ofAs(this.ds, other, idColumns: _*)(diffEncoder)
     }
 
     /**

--- a/src/test/scala/uk/co/gresearch/spark/diff/DiffSuite.scala
+++ b/src/test/scala/uk/co/gresearch/spark/diff/DiffSuite.scala
@@ -17,7 +17,7 @@
 
 package uk.co.gresearch.spark.diff
 
-import org.apache.spark.sql.{Dataset, Encoders, Row, SparkSession}
+import org.apache.spark.sql.{Dataset, Encoders, Row}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.scalatest.FunSuite
@@ -74,7 +74,7 @@ class DiffSuite extends FunSuite with SparkTestSession {
       .withChangeDiffValue("c")
       .withDeleteDiffValue("d")
       .withNochangeDiffValue("n")
-    val expected = DiffOptions("d", "l", "r", "i", "c", "d", "n", None)
+    val expected = DiffOptions("d", "l", "r", "i", "c", "d", "n")
     assert(options === expected)
   }
 
@@ -419,7 +419,7 @@ class DiffSuite extends FunSuite with SparkTestSession {
   }
 
   test("diff with custom diff options") {
-    val options = DiffOptions("action", "before", "after", "new", "change", "del", "eq", None)
+    val options = DiffOptions("action", "before", "after", "new", "change", "del", "eq")
 
     val expected = Seq(
       Row("eq", 1, "one", "one"),
@@ -497,8 +497,8 @@ class DiffSuite extends FunSuite with SparkTestSession {
 
     doTestRequirement(left.diff(right),
       "The datasets do not have the same schema.\n" +
-        "Left extra columns: value (StringType)\n" +
-        "Right extra columns: value (IntegerType)")
+        "left extra columns: value (StringType)\n" +
+        "right extra columns: value (IntegerType)")
   }
 
   test("diff with different nullability") {
@@ -525,8 +525,8 @@ class DiffSuite extends FunSuite with SparkTestSession {
 
     doTestRequirement(left.diff(right, "id"),
       "The datasets do not have the same schema.\n" +
-        "Left extra columns: value (StringType)\n" +
-        "Right extra columns: comment (StringType)")
+        "left extra columns: value (StringType)\n" +
+        "right extra columns: comment (StringType)")
   }
 
   test("diff with case-insensitive column names") {
@@ -551,8 +551,8 @@ class DiffSuite extends FunSuite with SparkTestSession {
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
       doTestRequirement(left.diff(right, "id"),
         "The datasets do not have the same schema.\n" +
-          "Left extra columns: id (IntegerType), value (StringType)\n" +
-          "Right extra columns: ID (IntegerType), VaLuE (StringType)")
+          "left extra columns: id (IntegerType), value (StringType)\n" +
+          "right extra columns: ID (IntegerType), VaLuE (StringType)")
     }
   }
 
@@ -567,9 +567,9 @@ class DiffSuite extends FunSuite with SparkTestSession {
     val right = Seq((1, 1, "str")).toDF("id", "seq", "value")
 
     doTestRequirement(left.diff(right, "id"),
-      "The number of columns doesn't match.\n" +
-        "Left column names (2): id, value\n" +
-        "Right column names (3): id, seq, value")
+      "The datasets do not have the same schema.\n" +
+        "left extra columns: \n" +
+        "right extra columns: seq (IntegerType)")
   }
 
   test("diff as U") {
@@ -589,7 +589,7 @@ class DiffSuite extends FunSuite with SparkTestSession {
   }
 
   test("diff as U with encoder and custom options") {
-    val options = DiffOptions("action", "before", "after", "new", "change", "del", "eq", None)
+    val options = DiffOptions("action", "before", "after", "new", "change", "del", "eq")
     val encoder = Encoders.product[DiffAsCustom]
 
     val actions = Seq(

--- a/src/test/scala/uk/co/gresearch/spark/diff/DiffSuite.scala
+++ b/src/test/scala/uk/co/gresearch/spark/diff/DiffSuite.scala
@@ -17,38 +17,12 @@
 
 package uk.co.gresearch.spark.diff
 
-import org.apache.spark.sql.{Dataset, Encoders, Row}
+import org.apache.spark.sql.{Dataset, Encoders, Row, SparkSession}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.scalatest.FunSuite
 
-case class Empty()
-case class Value(id: Int, value: Option[String])
-case class Value2(id: Int, seq: Option[Int], value: Option[String])
-case class Value3(id: Int, left_value: String, right_value: String, value: String)
-case class Value4(id: Int, diff: String)
-case class Value5(first_id: Int, id: String)
-case class Value6(id: Int, label: String)
-
-case class DiffAs(diff: String,
-                  id: Int,
-                  left_value: Option[String],
-                  right_value: Option[String])
-case class DiffAsCustom(action: String,
-                        id: Int,
-                        before_value: Option[String],
-                        after_value: Option[String])
-case class DiffAsSubset(diff: String,
-                        id: Int,
-                        left_value: Option[String])
-case class DiffAsExtra(diff: String,
-                       id: Int,
-                       left_value: Option[String],
-                       right_value: Option[String],
-                       extra: String)
-
 class DiffSuite extends FunSuite with SparkTestSession {
-
   import spark.implicits._
 
   lazy val left: Dataset[Value] = Seq(

--- a/src/test/scala/uk/co/gresearch/spark/diff/DiffSuite.scala
+++ b/src/test/scala/uk/co/gresearch/spark/diff/DiffSuite.scala
@@ -74,7 +74,7 @@ class DiffSuite extends FunSuite with SparkTestSession {
       .withChangeDiffValue("c")
       .withDeleteDiffValue("d")
       .withNochangeDiffValue("n")
-    val expected = DiffOptions("d", "l", "r", "i", "c", "d", "n")
+    val expected = DiffOptions("d", "l", "r", "i", "c", "d", "n", None)
     assert(options === expected)
   }
 
@@ -419,7 +419,7 @@ class DiffSuite extends FunSuite with SparkTestSession {
   }
 
   test("diff with custom diff options") {
-    val options = DiffOptions("action", "before", "after", "new", "change", "del", "eq")
+    val options = DiffOptions("action", "before", "after", "new", "change", "del", "eq", None)
 
     val expected = Seq(
       Row("eq", 1, "one", "one"),
@@ -589,7 +589,7 @@ class DiffSuite extends FunSuite with SparkTestSession {
   }
 
   test("diff as U with encoder and custom options") {
-    val options = DiffOptions("action", "before", "after", "new", "change", "del", "eq")
+    val options = DiffOptions("action", "before", "after", "new", "change", "del", "eq", None)
     val encoder = Encoders.product[DiffAsCustom]
 
     val actions = Seq(

--- a/src/test/scala/uk/co/gresearch/spark/diff/DiffSuiteWithComparators.scala
+++ b/src/test/scala/uk/co/gresearch/spark/diff/DiffSuiteWithComparators.scala
@@ -20,7 +20,8 @@ class DiffSuiteWithComparators extends FunSuite with SparkTestSession with MustM
   ))
   private val timestampStruct = StructType(Seq(
     StructField("id", IntegerType, false),
-    StructField("timestamp", TimestampType, false)
+    StructField("timestamp", TimestampType, false),
+    StructField("timestamp2", TimestampType, false)
   ))
   lazy val leftFloats: DataFrame = spark.createDataFrame(
     List(
@@ -38,22 +39,6 @@ class DiffSuiteWithComparators extends FunSuite with SparkTestSession with MustM
     ).asJava, floatStruct
   )
 
-  lazy val leftDouble: DataFrame = spark.createDataFrame(
-    List(
-      Row(1, 9.9),
-      Row(2, 9.9),
-      Row(3, 9.9)
-    ).asJava, doubleStruct
-  )
-
-  lazy val rightDoubles: DataFrame = spark.createDataFrame(
-    List(
-      Row(1, 9.8),
-      Row(2, 10.0),
-      Row(3, 11.0)
-    ).asJava, doubleStruct
-  )
-
   lazy val expectedDiffColumns: Seq[String] =
     Seq("diff", "id", "left_value", "right_value")
 
@@ -66,40 +51,41 @@ class DiffSuiteWithComparators extends FunSuite with SparkTestSession with MustM
       changeDiffValue = "Changed",
       deleteDiffValue = "Deleted",
       nochangeDiffValue = "Equal",
-      specialComparators = Map(
+      nullOutValidData = true,
+      columnComparators = Map(
         "float" -> DiffComparator.FuzzyNumberComparator(divergence)
       )
     ))
 
-    test("FloatFuzzyComparator with divergence: " + divergence) {
+    test("FuzzyNumberComparator with divergence: " + divergence) {
       val expected = Seq(
-        Seq(if(divergence >= 0.1) "Equal" else "Changed", if(divergence >= 0.1) null else "float", 1, 9.9f, 9.8f),
-        Seq(if(divergence >= 0.1) "Equal" else "Changed", if(divergence >= 0.1) null else "float", 2, 9.9f, 10.0f),
-        Seq("Changed", "float", 3, 9.9f, 11.0f)
+        Seq(if(divergence >= 0.1) "Equal" else "Changed", 1, if(divergence >= 0.1) null else 9.9f, if(divergence >= 0.1) null else 9.8f),
+        Seq(if(divergence >= 0.1) "Equal" else "Changed", 2 ,if(divergence >= 0.1) null else 9.9f, if(divergence >= 0.1) null else 10.0f),
+        Seq("Changed", 3, 9.9f, 11.0f)
       )
 
       val actual = diffWithOptions.of(leftFloats, rightFloats, "id").orderBy("id", "diff")
 
-      assert(actual.columns === Seq("diff", "changedColumn", "id", "left_float", "right_float"))
+      assert(actual.columns === Seq("diff", "id", "left_float", "right_float"))
       actual.collect().map(row => row.toSeq).zip(expected).foreach(x => x._1 mustBe x._2)
     }
   }
 
   private val leftTimeStamps = spark.createDataFrame(
     List(
-      Row(1, Timestamp.valueOf("2020-01-01 12:12:12.000")),
-      Row(2, Timestamp.valueOf("2020-01-01 12:12:12.000")),
-      Row(3, Timestamp.valueOf("2020-01-01 12:12:12.000")),
-      Row(4, Timestamp.valueOf("2020-01-01 13:12:12.000"))
+      Row(1, Timestamp.valueOf("2020-01-01 12:12:12.000"), Timestamp.valueOf("2020-01-01 12:12:12.000")),
+      Row(2, Timestamp.valueOf("2020-01-01 12:12:12.000"), Timestamp.valueOf("2020-01-01 12:12:12.000")),
+      Row(3, Timestamp.valueOf("2020-01-01 12:12:12.000"), Timestamp.valueOf("2020-01-01 12:12:12.000")),
+      Row(4, Timestamp.valueOf("2020-01-01 13:12:12.000"), Timestamp.valueOf("2020-01-01 12:12:12.000"))
     ).asJava, timestampStruct
   )
 
   private val rightTimeStamps = spark.createDataFrame(
     List(
-      Row(1, Timestamp.valueOf("2020-01-01 12:12:02.000")),
-      Row(2, Timestamp.valueOf("2020-01-01 12:12:22.000")),
-      Row(3, Timestamp.valueOf("2020-01-01 12:12:32.000")),
-      Row(4, Timestamp.valueOf("2020-01-01 12:12:13.000"))
+      Row(1, Timestamp.valueOf("2020-01-01 12:12:02.000"), Timestamp.valueOf("2020-01-01 12:12:18.000")),
+      Row(2, Timestamp.valueOf("2020-01-01 12:12:22.000"), Timestamp.valueOf("2020-01-01 12:12:16.000")),
+      Row(3, Timestamp.valueOf("2020-01-01 12:12:32.000"), Timestamp.valueOf("2020-01-01 12:12:12.000")),
+      Row(4, Timestamp.valueOf("2020-01-01 12:12:13.000"), Timestamp.valueOf("2020-01-01 12:12:12.000"))
     ).asJava, timestampStruct
   )
 
@@ -112,22 +98,27 @@ class DiffSuiteWithComparators extends FunSuite with SparkTestSession with MustM
       changeDiffValue = "Changed",
       deleteDiffValue = "Deleted",
       nochangeDiffValue = "Equal",
-      specialComparators = Map(
-        "timestamp" -> DiffComparator.FuzzyDateComparator(10, duration)
+      nullOutValidData = true,
+      datatypeComparators = Map(
+        TimestampType -> DiffComparator.FuzzyDateComparator(5, 5)   // timestamp column by default only get a 5 seconds tolerance
+      ),
+      columnComparators = Map(
+        "timestamp" -> DiffComparator.FuzzyDateComparator(10, duration) // except for this column
       )
     ))
 
     test("FuzzyDateComparator with duration: " + duration) {
       val expected = Seq(
-        Seq("Equal", null, 1, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:02.0")),
-        Seq("Equal", null, 2, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:22.0")),
-        Seq(if(duration >= 20) "Equal" else "Changed", if(duration >= 20) null else "timestamp", 3, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:32.0")),
-        Seq("Changed", "timestamp", 4, Timestamp.valueOf("2020-01-01 13:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:13.0"))
+        Seq("Changed", 1, null, null, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:18.0")),    // indicates that the default timestamp comparator is used for column timestamp2
+        Seq("Equal", 2, null, null, null, null),
+        Seq(if(duration >= 20) "Equal" else "Changed", 3, if(duration >= 20) null else Timestamp.valueOf("2020-01-01 12:12:12.0"),
+          if(duration >= 20) null else Timestamp.valueOf("2020-01-01 12:12:32.0"), null, null),
+        Seq("Changed", 4, Timestamp.valueOf("2020-01-01 13:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:13.0"), null, null)
       )
 
       val actual = diffWithOptions.of(leftTimeStamps, rightTimeStamps, "id").orderBy("id", "diff")
 
-      assert(actual.columns === Seq("diff", "changedColumn", "id", "left_timestamp", "right_timestamp"))
+      assert(actual.columns === Seq("diff", "id", "left_timestamp", "right_timestamp", "left_timestamp2", "right_timestamp2"))
       actual.collect().map(row => row.toSeq).zip(expected).foreach(x => x._1 mustBe x._2)
     }
   }
@@ -142,22 +133,24 @@ class DiffSuiteWithComparators extends FunSuite with SparkTestSession with MustM
       changeDiffValue = "Changed",
       deleteDiffValue = "Deleted",
       nochangeDiffValue = "Equal",
-      specialComparators = Map(
+      nullOutValidData = true,
+      ignoreColumns = Seq("timestamp2"),
+      columnComparators = Map(
         "timestamp" -> DiffComparator.FuzzyDateComparator(10, 10, tz)
       )
     ))
 
     test("FuzzyDateComparator with time zone: " + tz) {
       val expected = Seq(
-        Seq(if(tz == "UTC") "Equal" else "Changed", if(tz == "UTC") null else "timestamp", 1, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:02.0")),
-        Seq(if(tz == "UTC") "Equal" else "Changed", if(tz == "UTC") null else "timestamp", 2, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:22.0")),
-        Seq("Changed", "timestamp", 3, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:32.0")),
-        Seq(if(tz == "CET") "Equal" else "Changed", if(tz == "CET") null else "timestamp", 4, Timestamp.valueOf("2020-01-01 13:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:13.0"))
+        Seq(if(tz == "UTC") "Equal" else "Changed", 1, if(tz == "UTC") null else Timestamp.valueOf("2020-01-01 12:12:12.0"), if(tz == "UTC") null else Timestamp.valueOf("2020-01-01 12:12:02.0")),
+        Seq(if(tz == "UTC") "Equal" else "Changed", 2, if(tz == "UTC") null else Timestamp.valueOf("2020-01-01 12:12:12.0"), if(tz == "UTC") null else Timestamp.valueOf("2020-01-01 12:12:22.0")),
+        Seq("Changed", 3, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:32.0")),
+        Seq(if(tz == "CET") "Equal" else "Changed", 4, if(tz == "CET") null else Timestamp.valueOf("2020-01-01 13:12:12.0"), if(tz == "CET") null else Timestamp.valueOf("2020-01-01 12:12:13.0"))
       )
 
       val actual = diffWithTimezones.of(leftTimeStamps, rightTimeStamps, "id").orderBy("id", "diff")
 
-      assert(actual.columns === Seq("diff", "changedColumn", "id", "left_timestamp", "right_timestamp"))
+      assert(actual.columns === Seq("diff", "id", "left_timestamp", "right_timestamp"))
       actual.collect().map(row => row.toSeq).zip(expected).foreach(x => x._1 mustBe x._2)
     }
   }

--- a/src/test/scala/uk/co/gresearch/spark/diff/DiffSuiteWithComparators.scala
+++ b/src/test/scala/uk/co/gresearch/spark/diff/DiffSuiteWithComparators.scala
@@ -1,0 +1,164 @@
+package uk.co.gresearch.spark.diff
+
+import java.sql.Timestamp
+
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, Row}
+import org.scalatest.{FunSuite, MustMatchers}
+
+import scala.collection.JavaConverters._
+
+class DiffSuiteWithComparators extends FunSuite with SparkTestSession with MustMatchers {
+
+  private val floatStruct = StructType(Seq(
+    StructField("id", IntegerType, false),
+    StructField("float", FloatType, false)
+  ))
+  private val doubleStruct = StructType(Seq(
+    StructField("id", IntegerType, false),
+    StructField("float", DoubleType, false)
+  ))
+  private val timestampStruct = StructType(Seq(
+    StructField("id", IntegerType, false),
+    StructField("timestamp", TimestampType, false)
+  ))
+  lazy val leftFloats: DataFrame = spark.createDataFrame(
+    List(
+    Row(1, 9.9f),
+    Row(2, 9.9f),
+    Row(3, 9.9f)
+    ).asJava, floatStruct
+  )
+
+  lazy val rightFloats: DataFrame = spark.createDataFrame(
+    List(
+      Row(1, 9.8f),
+      Row(2, 10.0f),
+      Row(3, 11.0f)
+    ).asJava, floatStruct
+  )
+
+  lazy val leftDouble: DataFrame = spark.createDataFrame(
+    List(
+      Row(1, 9.9),
+      Row(2, 9.9),
+      Row(3, 9.9)
+    ).asJava, doubleStruct
+  )
+
+  lazy val rightDoubles: DataFrame = spark.createDataFrame(
+    List(
+      Row(1, 9.8),
+      Row(2, 10.0),
+      Row(3, 11.0)
+    ).asJava, doubleStruct
+  )
+
+  lazy val expectedDiffColumns: Seq[String] =
+    Seq("diff", "id", "left_value", "right_value")
+
+  for(divergence <- Seq(0.1f, 0.09f)) {
+    val diffWithOptions = new Diff(DiffOptions(
+      diffColumn = "diff",
+      leftColumnPrefix = "left",
+      rightColumnPrefix = "right",
+      insertDiffValue = "Inserted",
+      changeDiffValue = "Changed",
+      deleteDiffValue = "Deleted",
+      nochangeDiffValue = "Equal",
+      specialComparators = Map(
+        "float" -> DiffComparator.FuzzyNumberComparator(divergence)
+      )
+    ))
+
+    test("FloatFuzzyComparator with divergence: " + divergence) {
+      val expected = Seq(
+        Seq(if(divergence >= 0.1) "Equal" else "Changed", 1, 9.9f, 9.8f),
+        Seq(if(divergence >= 0.1) "Equal" else "Changed", 2, 9.9f, 10.0f),
+        Seq("Changed", 3, 9.9f, 11.0f)
+      )
+
+      val actual = diffWithOptions.of(leftFloats, rightFloats, "id").orderBy("id", "diff")
+
+      assert(actual.columns === Seq("diff", "id", "left_float", "right_float"))
+      actual.collect().map(row => row.toSeq).zip(expected).foreach(x => x._1 mustBe x._2)
+    }
+  }
+
+  private val leftTimeStamps = spark.createDataFrame(
+    List(
+      Row(1, Timestamp.valueOf("2020-01-01 12:12:12.000")),
+      Row(2, Timestamp.valueOf("2020-01-01 12:12:12.000")),
+      Row(3, Timestamp.valueOf("2020-01-01 12:12:12.000")),
+      Row(4, Timestamp.valueOf("2020-01-01 13:12:12.000"))
+    ).asJava, timestampStruct
+  )
+
+  private val rightTimeStamps = spark.createDataFrame(
+    List(
+      Row(1, Timestamp.valueOf("2020-01-01 12:12:02.000")),
+      Row(2, Timestamp.valueOf("2020-01-01 12:12:22.000")),
+      Row(3, Timestamp.valueOf("2020-01-01 12:12:32.000")),
+      Row(4, Timestamp.valueOf("2020-01-01 12:12:13.000"))
+    ).asJava, timestampStruct
+  )
+
+  for(duration <- Seq(10, 20)) {
+    val diffWithOptions = new Diff(DiffOptions(
+      diffColumn = "diff",
+      leftColumnPrefix = "left",
+      rightColumnPrefix = "right",
+      insertDiffValue = "Inserted",
+      changeDiffValue = "Changed",
+      deleteDiffValue = "Deleted",
+      nochangeDiffValue = "Equal",
+      specialComparators = Map(
+        "timestamp" -> DiffComparator.FuzzyDateComparator(10, duration)
+      )
+    ))
+
+    test("FuzzyDateComparator with duration: " + duration) {
+      val expected = Seq(
+        Seq("Equal", 1, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:02.0")),
+        Seq("Equal", 2, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:22.0")),
+        Seq(if(duration >= 20) "Equal" else "Changed", 3, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:32.0")),
+        Seq("Changed", 4, Timestamp.valueOf("2020-01-01 13:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:13.0"))
+      )
+
+      val actual = diffWithOptions.of(leftTimeStamps, rightTimeStamps, "id").orderBy("id", "diff")
+
+      assert(actual.columns === Seq("diff", "id", "left_timestamp", "right_timestamp"))
+      actual.collect().map(row => row.toSeq).zip(expected).foreach(x => x._1 mustBe x._2)
+    }
+  }
+
+  for(tz <- Seq("UTC", "CET")){
+
+    val diffWithTimezones = new Diff(DiffOptions(
+      diffColumn = "diff",
+      leftColumnPrefix = "left",
+      rightColumnPrefix = "right",
+      insertDiffValue = "Inserted",
+      changeDiffValue = "Changed",
+      deleteDiffValue = "Deleted",
+      nochangeDiffValue = "Equal",
+      specialComparators = Map(
+        "timestamp" -> DiffComparator.FuzzyDateComparator(10, 10, tz)
+      )
+    ))
+
+    test("FuzzyDateComparator with time zone: " + tz) {
+      val expected = Seq(
+        Seq(if(tz == "UTC") "Equal" else "Changed", 1, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:02.0")),
+        Seq(if(tz == "UTC") "Equal" else "Changed", 2, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:22.0")),
+        Seq("Changed", 3, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:32.0")),
+        Seq(if(tz == "CET") "Equal" else "Changed", 4, Timestamp.valueOf("2020-01-01 13:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:13.0"))
+      )
+
+      val actual = diffWithTimezones.of(leftTimeStamps, rightTimeStamps, "id").orderBy("id", "diff")
+
+      assert(actual.columns === Seq("diff", "id", "left_timestamp", "right_timestamp"))
+      actual.collect().map(row => row.toSeq).zip(expected).foreach(x => x._1 mustBe x._2)
+    }
+  }
+}

--- a/src/test/scala/uk/co/gresearch/spark/diff/DiffSuiteWithComparators.scala
+++ b/src/test/scala/uk/co/gresearch/spark/diff/DiffSuiteWithComparators.scala
@@ -73,14 +73,14 @@ class DiffSuiteWithComparators extends FunSuite with SparkTestSession with MustM
 
     test("FloatFuzzyComparator with divergence: " + divergence) {
       val expected = Seq(
-        Seq(if(divergence >= 0.1) "Equal" else "Changed", 1, 9.9f, 9.8f),
-        Seq(if(divergence >= 0.1) "Equal" else "Changed", 2, 9.9f, 10.0f),
-        Seq("Changed", 3, 9.9f, 11.0f)
+        Seq(if(divergence >= 0.1) "Equal" else "Changed", if(divergence >= 0.1) null else "float", 1, 9.9f, 9.8f),
+        Seq(if(divergence >= 0.1) "Equal" else "Changed", if(divergence >= 0.1) null else "float", 2, 9.9f, 10.0f),
+        Seq("Changed", "float", 3, 9.9f, 11.0f)
       )
 
       val actual = diffWithOptions.of(leftFloats, rightFloats, "id").orderBy("id", "diff")
 
-      assert(actual.columns === Seq("diff", "id", "left_float", "right_float"))
+      assert(actual.columns === Seq("diff", "changedColumn", "id", "left_float", "right_float"))
       actual.collect().map(row => row.toSeq).zip(expected).foreach(x => x._1 mustBe x._2)
     }
   }
@@ -119,15 +119,15 @@ class DiffSuiteWithComparators extends FunSuite with SparkTestSession with MustM
 
     test("FuzzyDateComparator with duration: " + duration) {
       val expected = Seq(
-        Seq("Equal", 1, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:02.0")),
-        Seq("Equal", 2, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:22.0")),
-        Seq(if(duration >= 20) "Equal" else "Changed", 3, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:32.0")),
-        Seq("Changed", 4, Timestamp.valueOf("2020-01-01 13:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:13.0"))
+        Seq("Equal", null, 1, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:02.0")),
+        Seq("Equal", null, 2, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:22.0")),
+        Seq(if(duration >= 20) "Equal" else "Changed", if(duration >= 20) null else "timestamp", 3, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:32.0")),
+        Seq("Changed", "timestamp", 4, Timestamp.valueOf("2020-01-01 13:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:13.0"))
       )
 
       val actual = diffWithOptions.of(leftTimeStamps, rightTimeStamps, "id").orderBy("id", "diff")
 
-      assert(actual.columns === Seq("diff", "id", "left_timestamp", "right_timestamp"))
+      assert(actual.columns === Seq("diff", "changedColumn", "id", "left_timestamp", "right_timestamp"))
       actual.collect().map(row => row.toSeq).zip(expected).foreach(x => x._1 mustBe x._2)
     }
   }
@@ -149,15 +149,15 @@ class DiffSuiteWithComparators extends FunSuite with SparkTestSession with MustM
 
     test("FuzzyDateComparator with time zone: " + tz) {
       val expected = Seq(
-        Seq(if(tz == "UTC") "Equal" else "Changed", 1, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:02.0")),
-        Seq(if(tz == "UTC") "Equal" else "Changed", 2, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:22.0")),
-        Seq("Changed", 3, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:32.0")),
-        Seq(if(tz == "CET") "Equal" else "Changed", 4, Timestamp.valueOf("2020-01-01 13:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:13.0"))
+        Seq(if(tz == "UTC") "Equal" else "Changed", if(tz == "UTC") null else "timestamp", 1, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:02.0")),
+        Seq(if(tz == "UTC") "Equal" else "Changed", if(tz == "UTC") null else "timestamp", 2, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:22.0")),
+        Seq("Changed", "timestamp", 3, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:32.0")),
+        Seq(if(tz == "CET") "Equal" else "Changed", if(tz == "CET") null else "timestamp", 4, Timestamp.valueOf("2020-01-01 13:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:13.0"))
       )
 
       val actual = diffWithTimezones.of(leftTimeStamps, rightTimeStamps, "id").orderBy("id", "diff")
 
-      assert(actual.columns === Seq("diff", "id", "left_timestamp", "right_timestamp"))
+      assert(actual.columns === Seq("diff", "changedColumn", "id", "left_timestamp", "right_timestamp"))
       actual.collect().map(row => row.toSeq).zip(expected).foreach(x => x._1 mustBe x._2)
     }
   }

--- a/src/test/scala/uk/co/gresearch/spark/diff/DiffSuiteWithComparators.scala
+++ b/src/test/scala/uk/co/gresearch/spark/diff/DiffSuiteWithComparators.scala
@@ -76,7 +76,8 @@ class DiffSuiteWithComparators extends FunSuite with SparkTestSession with MustM
       Row(1, Timestamp.valueOf("2020-01-01 12:12:12.000"), Timestamp.valueOf("2020-01-01 12:12:12.000")),
       Row(2, Timestamp.valueOf("2020-01-01 12:12:12.000"), Timestamp.valueOf("2020-01-01 12:12:12.000")),
       Row(3, Timestamp.valueOf("2020-01-01 12:12:12.000"), Timestamp.valueOf("2020-01-01 12:12:12.000")),
-      Row(4, Timestamp.valueOf("2020-01-01 13:12:12.000"), Timestamp.valueOf("2020-01-01 12:12:12.000"))
+      Row(4, Timestamp.valueOf("2020-01-01 13:12:12.000"), Timestamp.valueOf("2020-01-01 12:12:12.000")),
+      Row(5, Timestamp.valueOf("2020-01-01 12:12:12.000"), null)
     ).asJava, timestampStruct
   )
 
@@ -85,7 +86,8 @@ class DiffSuiteWithComparators extends FunSuite with SparkTestSession with MustM
       Row(1, Timestamp.valueOf("2020-01-01 12:12:02.000"), Timestamp.valueOf("2020-01-01 12:12:18.000")),
       Row(2, Timestamp.valueOf("2020-01-01 12:12:22.000"), Timestamp.valueOf("2020-01-01 12:12:16.000")),
       Row(3, Timestamp.valueOf("2020-01-01 12:12:32.000"), Timestamp.valueOf("2020-01-01 12:12:12.000")),
-      Row(4, Timestamp.valueOf("2020-01-01 12:12:13.000"), Timestamp.valueOf("2020-01-01 12:12:12.000"))
+      Row(4, Timestamp.valueOf("2020-01-01 12:12:13.000"), Timestamp.valueOf("2020-01-01 12:12:12.000")),
+      Row(5, Timestamp.valueOf("2020-01-01 12:12:12.000"), null)
     ).asJava, timestampStruct
   )
 
@@ -113,7 +115,8 @@ class DiffSuiteWithComparators extends FunSuite with SparkTestSession with MustM
         Seq("Equal", 2, null, null, null, null),
         Seq(if(duration >= 20) "Equal" else "Changed", 3, if(duration >= 20) null else Timestamp.valueOf("2020-01-01 12:12:12.0"),
           if(duration >= 20) null else Timestamp.valueOf("2020-01-01 12:12:32.0"), null, null),
-        Seq("Changed", 4, Timestamp.valueOf("2020-01-01 13:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:13.0"), null, null)
+        Seq("Changed", 4, Timestamp.valueOf("2020-01-01 13:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:13.0"), null, null),
+        Seq("Equal", 5, null, null, null, null)
       )
 
       val actual = diffWithOptions.of(leftTimeStamps, rightTimeStamps, "id").orderBy("id", "diff")
@@ -145,7 +148,8 @@ class DiffSuiteWithComparators extends FunSuite with SparkTestSession with MustM
         Seq(if(tz == "UTC") "Equal" else "Changed", 1, if(tz == "UTC") null else Timestamp.valueOf("2020-01-01 12:12:12.0"), if(tz == "UTC") null else Timestamp.valueOf("2020-01-01 12:12:02.0")),
         Seq(if(tz == "UTC") "Equal" else "Changed", 2, if(tz == "UTC") null else Timestamp.valueOf("2020-01-01 12:12:12.0"), if(tz == "UTC") null else Timestamp.valueOf("2020-01-01 12:12:22.0")),
         Seq("Changed", 3, Timestamp.valueOf("2020-01-01 12:12:12.0"), Timestamp.valueOf("2020-01-01 12:12:32.0")),
-        Seq(if(tz == "CET") "Equal" else "Changed", 4, if(tz == "CET") null else Timestamp.valueOf("2020-01-01 13:12:12.0"), if(tz == "CET") null else Timestamp.valueOf("2020-01-01 12:12:13.0"))
+        Seq(if(tz == "CET") "Equal" else "Changed", 4, if(tz == "CET") null else Timestamp.valueOf("2020-01-01 13:12:12.0"), if(tz == "CET") null else Timestamp.valueOf("2020-01-01 12:12:13.0")),
+        Seq(if(tz == "UTC") "Equal" else "Changed", 5, if(tz == "UTC") null else Timestamp.valueOf("2020-01-01 12:12:12.000") , if(tz == "UTC") null else Timestamp.valueOf("2020-01-01 12:12:12.000"))
       )
 
       val actual = diffWithTimezones.of(leftTimeStamps, rightTimeStamps, "id").orderBy("id", "diff")

--- a/src/test/scala/uk/co/gresearch/spark/diff/SparkTestSession.scala
+++ b/src/test/scala/uk/co/gresearch/spark/diff/SparkTestSession.scala
@@ -23,7 +23,8 @@ import org.apache.spark.sql.catalyst.plans.SQLHelper
 
 trait SparkTestSession extends SQLHelper {
 
-  lazy val spark: SparkSession = {
+  lazy val spark:
+    SparkSession = {
     SparkSession
       .builder()
       .master("local[1]")
@@ -45,5 +46,30 @@ trait SparkTestSession extends SQLHelper {
     SparkSession.setActiveSession(spark)
     super.withSQLConf(pairs:_*)(f)
   }
-
 }
+
+
+case class Empty()
+case class Value(id: Int, value: Option[String])
+case class Value2(id: Int, seq: Option[Int], value: Option[String])
+case class Value3(id: Int, left_value: String, right_value: String, value: String)
+case class Value4(id: Int, diff: String)
+case class Value5(first_id: Int, id: String)
+case class Value6(id: Int, label: String)
+
+case class DiffAs(diff: String,
+                  id: Int,
+                  left_value: Option[String],
+                  right_value: Option[String])
+case class DiffAsCustom(action: String,
+                        id: Int,
+                        before_value: Option[String],
+                        after_value: Option[String])
+case class DiffAsSubset(diff: String,
+                        id: Int,
+                        left_value: Option[String])
+case class DiffAsExtra(diff: String,
+                       id: Int,
+                       left_value: Option[String],
+                       right_value: Option[String],
+                       extra: String)


### PR DESCRIPTION
Adds:
* Diff Comporator trait
* allowing for implementing custom comparators
* fuzzy comparators for numbers and dates
* option to ignore specified columns
* option assigning comporators to columns based on datatypes
* option assigning comporators to specific columns
* option to null / blank results considered equal

Please see Diff.md, tests and comments.