### PR TITLE
Add withRowNumbers transformation to Scala, Java and Python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ for the iterator.
 
 **[Histogram](HISTOGRAM.md):** A `histogram` transformation that computes the histogram DataFrame for a value column.
 
+**[Global Row Number](ROW_NUMBER.md):** A `withRowNumbers` transformation that provides the global row number w.r.t.
+the current order of the Dataset, or any given order. In contrast to the existing SQL function `row_number`, which
+works requires a window spec, this transformation provides the row number across the entire Dataset without scaling problems.
+
 **[Partitioned Writing](PARTITIONING.md):** The `writePartitionedBy` action writes your `Dataset` partitioned and
 efficiently laid out with a single operation.
 

--- a/ROW_NUMBER.md
+++ b/ROW_NUMBER.md
@@ -79,7 +79,7 @@ df.withRowNumbers($"id".desc, $"value").show()
 
 In Java:
 ```java
-RowNumbers.withOrderColumns(df.col("id").desc()).of(df).show();
+RowNumbers.withOrderColumns(df.col("id").desc(), df.col("value")).of(df).show();
 // +---+-----+----------+
 // | id|value|row_number|
 // +---+-----+----------+
@@ -92,7 +92,7 @@ RowNumbers.withOrderColumns(df.col("id").desc()).of(df).show();
 
 In Python:
 ```python
-df.with_row_numbers(order=df.id.desc()).show()
+df.with_row_numbers(order=[df.id.desc(), df.value]).show()
 # +---+-----+----------+
 # | id|value|row_number|
 # +---+-----+----------+

--- a/ROW_NUMBER.md
+++ b/ROW_NUMBER.md
@@ -32,13 +32,40 @@ df.withRowNumbers().show()
 // +---+-----+----------+
 ```
 
+In Java:
+```java
+import uk.co.gresearch.spark.RowNumbers;
+
+RowNumbers.of(df).show();
+// +---+-----+----------+
+// | id|value|row_number|
+// +---+-----+----------+
+// |  1|  one|         1|
+// |  2|  two|         2|
+// |  2|  TWO|         3|
+// |  3|three|         4|
+// +---+-----+----------+
+```
+
+In Python:
+```python
+import gresearch.spark
+
+df.with_row_numbers().show()
+# +---+-----+----------+
+# | id|value|row_number|
+# +---+-----+----------+
+# |  1|  one|         1|
+# |  2|  two|         2|
+# |  2|  TWO|         3|
+# |  3|three|         4|
+# +---+-----+----------+
+```
+
 ## Row number order
 Row numbers are assigned in the current order of the Dataset. If you want a specific order, provide columns as follows:
 
 ```scala
-import uk.co.gresearch.spark._
-
-val df = Seq((1, "one"), (2, "two"), (3, "three")).toDF("id", "value")
 df.withRowNumbers($"id".desc, $"value").show()
 // +---+-----+----------+
 // | id|value|row_number|
@@ -48,6 +75,32 @@ df.withRowNumbers($"id".desc, $"value").show()
 // |  2|  two|         3|
 // |  1|  one|         4|
 // +---+-----+----------+
+```
+
+In Java:
+```java
+RowNumbers.withOrderColumns(df.col("id").desc()).of(df).show();
+// +---+-----+----------+
+// | id|value|row_number|
+// +---+-----+----------+
+// |  3|three|         1|
+// |  2|  TWO|         2|
+// |  2|  two|         3|
+// |  1|  one|         4|
+// +---+-----+----------+
+```
+
+In Python:
+```python
+df.with_row_numbers(order=df.id.desc()).show()
+# +---+-----+----------+
+# | id|value|row_number|
+# +---+-----+----------+
+# |  3|three|         1|
+# |  2|  TWO|         2|
+# |  2|  two|         3|
+# |  1|  one|         4|
+# +---+-----+----------+
 ```
 
 ## Row number column name
@@ -66,6 +119,32 @@ df.withRowNumbers(rowNumberColumnName="row").show()
 // +---+-----+---+
 ```
 
+In Java:
+```java
+RowNumbers.withRowNumberColumnName("row").of(df).show();
+// +---+-----+---+
+// | id|value|row|
+// +---+-----+---+
+// |  1|  one|  1|
+// |  2|  TWO|  2|
+// |  2|  two|  3|
+// |  3|three|  4|
+// +---+-----+---+
+```
+
+In Python:
+```python
+df.with_row_numbers(row_number_column_name='row').show()
+# +---+-----+---+
+# | id|value|row|
+# +---+-----+---+
+# |  1|  one|  1|
+# |  2|  TWO|  2|
+# |  2|  two|  3|
+# |  3|three|  4|
+# +---+-----+---+
+```
+
 ## Cached / persisted intermediate Dataset
 
 The `withRowNumbers` transformation requires the input Dataset to be
@@ -79,17 +158,53 @@ import org.apache.spark.storage.StorageLevel
 val dfWithRowNumbers = df.withRowNumbers(storageLevel=StorageLevel.DISK_ONLY)
 ```
 
-If you want control over when to un-persist this intermediate Dataset, you can provide an `unpersistHandle` and call it
+In Java:
+```java
+import org.apache.spark.storage.StorageLevel;
+
+Dataset<Row> dfWithRowNumbers = RowNumbers.withStorageLevel(StorageLevel.DISK_ONLY()).of(df);
+```
+
+In Python:
+```python
+from pyspark.storagelevel import StorageLevel
+
+df_with_row_numbers = df.with_row_numbers(storage_level=StorageLevel.DISK_ONLY)
+```
+
+## Un-persist intermediate Dataset
+
+If you want control over when to un-persist this intermediate Dataset, you can provide an `UnpersistHandle` and call it
 when you are done with the result Dataset:
 
 ```scala
 import uk.co.gresearch.spark.UnpersistHandle
 
 val unpersist = UnpersistHandle()
-val dfWithRowNumbers = df.withRowNumbers(unpersistHandle=unpersist)
+val dfWithRowNumbers = df.withRowNumbers(unpersistHandle=unpersist);
 
 // after you are done with dfWithRowNumbers you may want to call unpersist()
 unpersist(blocking=false)
+```
+
+In Java:
+```java
+import uk.co.gresearch.spark.UnpersistHandle;
+
+UnpersistHandle unpersist = new UnpersistHandle();
+Dataset<Row> dfWithRowNumbers = RowNumbers.withUnpersistHandle(unpersist).of(df);
+
+// after you are done with dfWithRowNumbers you may want to call unpersist()
+unpersist.apply(true);
+```
+
+In Python:
+```python
+unpersist = spark.unpersist_handle()
+df_with_row_numbers = df.with_row_numbers(unpersist_handle=unpersist)
+
+# after you are done with df_with_row_numbers you may want to call unpersist()
+unpersist(blocking=True)
 ```
 
 ## Spark warning

--- a/ROW_NUMBER.md
+++ b/ROW_NUMBER.md
@@ -1,0 +1,103 @@
+# Global Row Number
+
+Spark provides the [SQL function `row_number`](https://spark.apache.org/docs/latest/api/sql/index.html#row_number),
+which assigns each row a consecutive number, starting from 1. This function works on a [Window](https://spark.apache.org/docs/latest/api/scala/org/apache/spark/sql/expressions/Window.html).
+Assigning a row number over the entire Dataset will load the entire dataset into a single partition / executor.
+This does not scale.
+
+Spark extensions provide the `Dataset` transformation `withRowNumbers`, which assigns a global row number while scaling:
+
+```scala
+val df = Seq((1, "one"), (2, "TWO"), (2, "two"), (3, "three")).toDF("id", "value")
+df.show()
+// +---+-----+
+// | id|value|
+// +---+-----+
+// |  1|  one|
+// |  2|  TWO|
+// |  2|  two|
+// |  3|three|
+// +---+-----+
+
+import uk.co.gresearch.spark._
+
+df.withRowNumbers().show()
+// +---+-----+----------+
+// | id|value|row_number|
+// +---+-----+----------+
+// |  1|  one|         1|
+// |  2|  two|         2|
+// |  2|  TWO|         3|
+// |  3|three|         4|
+// +---+-----+----------+
+```
+
+## Row number order
+Row numbers are assigned in the current order of the Dataset. If you want a specific order, provide columns as follows:
+
+```scala
+import uk.co.gresearch.spark._
+
+val df = Seq((1, "one"), (2, "two"), (3, "three")).toDF("id", "value")
+df.withRowNumbers($"id".desc, $"value").show()
+// +---+-----+----------+
+// | id|value|row_number|
+// +---+-----+----------+
+// |  3|three|         1|
+// |  2|  TWO|         2|
+// |  2|  two|         3|
+// |  1|  one|         4|
+// +---+-----+----------+
+```
+
+## Row number column name
+
+The column name that contains the row number can be changed by providing the `rowNumberColumnName` argument:
+
+```scala
+df.withRowNumbers(rowNumberColumnName="row").show()
+// +---+-----+---+
+// | id|value|row|
+// +---+-----+---+
+// |  1|  one|  1|
+// |  2|  TWO|  2|
+// |  2|  two|  3|
+// |  3|three|  4|
+// +---+-----+---+
+```
+
+## Cached / persisted intermediate Dataset
+
+The `withRowNumbers` transformation requires the input Dataset to be
+[cached](https://spark.apache.org/docs/latest/api/scala/org/apache/spark/sql/Dataset.html#cache():Dataset.this.type) /
+[persisted](https://spark.apache.org/docs/latest/api/scala/org/apache/spark/sql/Dataset.html#persist(newLevel:org.apache.spark.storage.StorageLevel):Dataset.this.type),
+after adding an intermediate column. You can specify the level of persistence through the `storageLevel` parameter.
+
+```scala
+import org.apache.spark.storage.StorageLevel
+
+val dfWithRowNumbers = df.withRowNumbers(storageLevel=StorageLevel.DISK_ONLY)
+```
+
+If you want control over when to un-persist this intermediate Dataset, you can provide an `unpersistHandle` and call it
+when you are done with the result Dataset:
+
+```scala
+import uk.co.gresearch.spark.UnpersistHandle
+
+val unpersist = UnpersistHandle()
+val dfWithRowNumbers = df.withRowNumbers(unpersistHandle=unpersist)
+
+// after you are done with dfWithRowNumbers you may want to call unpersist()
+unpersist(blocking=false)
+```
+
+## Spark warning
+
+You will recognize that Spark logs the following warning:
+
+```
+WindowExec: No Partition Defined for Window operation! Moving all data to a single partition, this can cause serious performance degradation.
+```
+This warning is unavoidable, because `withRowNumbers` has to pull information about the initial partitions into a single partition.
+Fortunately, there are only 12 Bytes per input partition required, so this amount of data usually fits into a single partition and the warning can safely be ignored.

--- a/python/test/test_row_number.py
+++ b/python/test/test_row_number.py
@@ -1,0 +1,144 @@
+#  Copyright 2022 G-Research
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+
+logger = logging.getLogger()
+logger.level = logging.INFO
+
+import unittest
+
+from pyspark.sql import Row
+from pyspark.storagelevel import StorageLevel
+from py4j.java_gateway import JavaObject
+
+from spark_common import SparkTest
+import gresearch.spark
+
+
+class RowNumberTest(SparkTest):
+
+    @classmethod
+    def setUpClass(cls):
+        super(RowNumberTest, cls).setUpClass()
+
+        cls.df1 = cls.spark.createDataFrame([
+            (1, 'one'),
+            (2, 'two'),
+            (3, 'three'),
+            (4, 'four'),
+        ], ['id', 'value'])
+        cls.expected1 = [
+            {'id': 1, 'value': 'one', 'row_number': 1},
+            {'id': 2, 'value': 'two', 'row_number': 2},
+            {'id': 3, 'value': 'three', 'row_number': 3},
+            {'id': 4, 'value': 'four', 'row_number': 4},
+        ]
+        cls.expected1Desc = [
+            {'id': 1, 'value': 'one', 'row_number': 4},
+            {'id': 2, 'value': 'two', 'row_number': 3},
+            {'id': 3, 'value': 'three', 'row_number': 2},
+            {'id': 4, 'value': 'four', 'row_number': 1},
+        ]
+
+        cls.df2 = cls.spark.createDataFrame([
+            (1, 'one'),
+            (2, 'TWO'),
+            (2, 'two'),
+            (3, 'three'),
+        ], ['id', 'value'])
+        cls.expected2 = [
+            {'id': 1, 'value': 'one', 'row_number': 1},
+            {'id': 2, 'value': 'TWO', 'row_number': 2},
+            {'id': 2, 'value': 'two', 'row_number': 3},
+            {'id': 3, 'value': 'three', 'row_number': 4},
+        ]
+        cls.expected2Desc = [
+            {'id': 1, 'value': 'one', 'row_number': 4},
+            {'id': 2, 'value': 'TWO', 'row_number': 3},
+            {'id': 2, 'value': 'two', 'row_number': 2},
+            {'id': 3, 'value': 'three', 'row_number': 1},
+        ]
+
+    def test_row_numbers(self):
+        rows = self.df1.with_row_numbers().orderBy('id', 'value').collect()
+        self.assertEqual(self.expected1, [row.asDict() for row in rows])
+
+    def test_row_numbers_order_one_column(self):
+        for order in ['id', ['id'], self.df1.id, [self.df1.id]]:
+            with self.subTest(order=order):
+                rows = self.df1.with_row_numbers(order=order).orderBy('id', 'value').collect()
+                self.assertEqual(self.expected1, [row.asDict() for row in rows])
+
+    def test_row_numbers_order_two_columns(self):
+        for order in [['id', 'value'], [self.df2.id, self.df2.value]]:
+            with self.subTest(order=order):
+                rows = self.df2.with_row_numbers(order=order).orderBy('id', 'value').collect()
+                self.assertEqual(self.expected2, [row.asDict() for row in rows])
+
+    def test_row_numbers_order_not_asc_one_column(self):
+        for order in ['id', ['id'], self.df1.id, [self.df1.id]]:
+            with self.subTest(order=order):
+                rows = self.df1.with_row_numbers(order=order, ascending=False).orderBy('id', 'value').collect()
+                self.assertEqual(self.expected1Desc, [row.asDict() for row in rows])
+
+    def test_row_numbers_order_not_asc_two_columns(self):
+        for order in [['id', 'value'], [self.df2.id, self.df2.value]]:
+            with self.subTest(order=order):
+                rows = self.df2.with_row_numbers(order=order, ascending=False).orderBy('id', 'value').collect()
+                self.assertEqual(self.expected2Desc, [row.asDict() for row in rows])
+
+    def test_row_numbers_order_desc_one_column(self):
+        for order in [self.df1.id.desc(), [self.df1.id.desc()]]:
+            with self.subTest(order=order):
+                rows = self.df1.with_row_numbers(order=order).orderBy('id', 'value').collect()
+                self.assertEqual(self.expected1Desc, [row.asDict() for row in rows])
+
+    def test_row_numbers_order_desc_two_columns(self):
+        for order in [[self.df2.id.desc(), self.df2.value.desc()]]:
+            with self.subTest(order=order):
+                rows = self.df2.with_row_numbers(order=order).orderBy('id', 'value').collect()
+                self.assertEqual(self.expected2Desc, [row.asDict() for row in rows])
+
+    def test_row_numbers_unpersist(self):
+        for storage_level in [StorageLevel.MEMORY_AND_DISK, StorageLevel.MEMORY_ONLY, StorageLevel.DISK_ONLY]:
+            with self.subTest(storage_level=storage_level):
+                # make sure the cache is clear
+                jcm = self.spark._jsparkSession.sharedState().cacheManager()
+                jcm.clearCache()
+                self.assertTrue(jcm.isEmpty())
+
+                unpersist = self.spark.unpersist_handle()
+                self.df1.with_row_numbers(storage_level=storage_level, unpersist_handle=unpersist) \
+                    .orderBy('id', 'value').collect()
+
+                # the cache should not be empty now
+                self.assertFalse(jcm.isEmpty())
+                unpersist(blocking=True)
+
+                # this should have removed the only DataFrame from the cache
+                self.assertTrue(jcm.isEmpty())
+
+                # calling unpersist again does not hurt, this time without blocking
+                unpersist()
+
+    def test_row_numbers_row_number_col_name(self):
+        rows = self.df1.with_row_numbers(row_number_column_name='row').orderBy('id', 'value').collect()
+        self.assertEqual([{'row' if k == 'row_number' else k: v for k, v in row.items()}
+                          for row in self.expected1],
+                         [row.asDict() for row in rows])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/main/scala/uk/co/gresearch/spark/RowNumbers.scala
+++ b/src/main/scala/uk/co/gresearch/spark/RowNumbers.scala
@@ -1,0 +1,73 @@
+package uk.co.gresearch.spark
+
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.{Column, DataFrame, Dataset, functions}
+import org.apache.spark.sql.functions.{coalesce, col, lit, max, monotonically_increasing_id, spark_partition_id, sum}
+import org.apache.spark.storage.StorageLevel
+
+object RowNumbers {
+  def of[D](df: Dataset[D],
+            rowNumberColumnName: String = "row_number",
+            storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK,
+            unpersistHandle: UnpersistHandle = UnpersistHandle.Noop,
+            orderColumns: Seq[Column] = Seq.empty): DataFrame = {
+    // define some column names that do not exist in ds
+    val prefix = distinctPrefixFor(df.columns)
+    val monoIdColumnName = prefix + "mono_id"
+    val partitionIdColumnName = prefix + "partition_id"
+    val localRowNumberColumnName = prefix + "local_row_number"
+    val maxLocalRowNumberColumnName = prefix + "max_local_row_number"
+    val cumRowNumbersColumnName = prefix + "cum_row_numbers"
+    val partitionOffsetColumnName = prefix + "partition_offset"
+
+    // if no order is given, we preserve existing order
+    val dfOrdered = if (orderColumns.isEmpty) df.withColumn(monoIdColumnName, monotonically_increasing_id()) else df.orderBy(orderColumns: _*)
+    val order = if (orderColumns.isEmpty) Seq(col(monoIdColumnName)) else orderColumns
+
+    // add partition ids and local row numbers
+    val localRowNumberWindow = Window.partitionBy(partitionIdColumnName).orderBy(order: _*)
+    val dfWithPartitionId = dfOrdered
+      .withColumn(partitionIdColumnName, spark_partition_id())
+      .persist(storageLevel)
+    unpersistHandle.setDataFrame(dfWithPartitionId)
+    val dfWithLocalRowNumbers = dfWithPartitionId
+      .withColumn(localRowNumberColumnName, functions.row_number().over(localRowNumberWindow))
+
+    // compute row offset for the partitions
+    val cumRowNumbersWindow = Window.orderBy(partitionIdColumnName)
+      .rowsBetween(Window.unboundedPreceding, Window.currentRow)
+    val partitionOffsets = dfWithLocalRowNumbers
+      .groupBy(partitionIdColumnName)
+      .agg(max(localRowNumberColumnName).alias(maxLocalRowNumberColumnName))
+      .withColumn(cumRowNumbersColumnName, sum(maxLocalRowNumberColumnName).over(cumRowNumbersWindow))
+      .select(col(partitionIdColumnName) + 1 as partitionIdColumnName, col(cumRowNumbersColumnName).as(partitionOffsetColumnName))
+
+    // compute global row number by adding local row number with partition offset
+    val partitionOffsetColumn = coalesce(col(partitionOffsetColumnName), lit(0))
+    dfWithLocalRowNumbers.join(partitionOffsets, Seq(partitionIdColumnName), "left")
+      .withColumn(rowNumberColumnName, col(localRowNumberColumnName) + partitionOffsetColumn)
+      .drop(monoIdColumnName, partitionIdColumnName, localRowNumberColumnName, partitionOffsetColumnName)
+  }
+}
+
+class UnpersistHandle {
+  var df: Option[DataFrame] = None
+
+  def setDataFrame(dataframe: DataFrame): Unit = {
+    if (df.isDefined) throw new IllegalStateException("DataFrame has been set already. It cannot be reused once used with withRowNumbers.")
+    this.df = Some(dataframe)
+  }
+
+  def apply(): Unit = {
+    this.df.getOrElse(throw new IllegalStateException("DataFrame has to be set first")).unpersist()
+  }
+
+  def apply(blocking: Boolean): Unit = {
+    this.df.getOrElse(throw new IllegalStateException("DataFrame has to be set first")).unpersist(blocking)
+  }
+}
+
+object UnpersistHandle {
+  def apply(): UnpersistHandle = new UnpersistHandle()
+  def Noop = new UnpersistHandle()
+}

--- a/src/main/scala/uk/co/gresearch/spark/package.scala
+++ b/src/main/scala/uk/co/gresearch/spark/package.scala
@@ -52,7 +52,6 @@ package object spark {
    *
    * @param string  a string
    * @param strings more strings
-   * @return
    */
   @scala.annotation.varargs
   def backticks(string: String, strings: String*): String =
@@ -135,61 +134,195 @@ package object spark {
         .partitionBy(partitionColumnsMap.keys.toSeq: _*)
     }
 
+    /**
+     * Groups the Dataset and sorts the groups using the specified columns, so we can run
+     * further process the sorted groups. See [[SortedGroupByDataset]] for all the available
+     * functions.
+     *
+     * {{{
+     *   // Enumerate elements in the sorted group
+     *   ds.groupBySorted($"department")($"salery")
+     *     .flatMapSortedGroups((key, it) => it.zipWithIndex)
+     * }}}
+     *
+     * @param cols grouping columns
+     * @param order sort columns
+     */
     def groupBySorted[K: Ordering : Encoder](cols: Column*)(order: Column*): SortedGroupByDataset[K, T] = {
       implicit val encoder: Encoder[(K, T)] = Encoders.tuple(implicitly[Encoder[K]], implicitly[Encoder[T]])
       SortedGroupByDataset(ds, cols, order, None)
     }
 
+    /**
+     * Groups the Dataset and sorts the groups using the specified columns, so we can run
+     * further process the sorted groups. See [[SortedGroupByDataset]] for all the available
+     * functions.
+     *
+     * {{{
+     *   // Enumerate elements in the sorted group
+     *   ds.groupBySorted(10)($"department")($"salery")
+     *     .flatMapSortedGroups((key, it) => it.zipWithIndex)
+     * }}}
+     *
+     * @param partitions number of partitions
+     * @param cols grouping columns
+     * @param order sort columns
+     */
     def groupBySorted[K: Ordering : Encoder](partitions: Int)(cols: Column*)(order: Column*): SortedGroupByDataset[K, T] = {
       implicit val encoder: Encoder[(K, T)] = Encoders.tuple(implicitly[Encoder[K]], implicitly[Encoder[T]])
       SortedGroupByDataset(ds, cols, order, Some(partitions))
     }
 
+    /**
+     * Groups the Dataset and sorts the groups using the specified columns, so we can run
+     * further process the sorted groups. See [[SortedGroupByDataset]] for all the available
+     * functions.
+     *
+     * {{{
+     *   // Enumerate elements in the sorted group
+     *   ds.groupByKeySorted(row => row.getInt(0), 10)(row => row.getInt(1))
+     *     .flatMapSortedGroups((key, it) => it.zipWithIndex)
+     * }}}
+     *
+     * @param partitions number of partitions
+     * @param key grouping key
+     * @param order sort key
+     */
     def groupByKeySorted[K: Ordering : Encoder, O: Encoder](key: T => K, partitions: Int)(order: T => O): SortedGroupByDataset[K, T] =
       groupByKeySorted(key, Some(partitions))(order)
 
+    /**
+     * Groups the Dataset and sorts the groups using the specified columns, so we can run
+     * further process the sorted groups. See [[SortedGroupByDataset]] for all the available
+     * functions.
+     *
+     * {{{
+     *   // Enumerate elements in the sorted group
+     *   ds.groupByKeySorted(row => row.getInt(0), 10)(row => row.getInt(1), true)
+     *     .flatMapSortedGroups((key, it) => it.zipWithIndex)
+     * }}}
+     *
+     * @param partitions number of partitions
+     * @param key grouping key
+     * @param order sort key
+     * @param reverse sort reverse order
+     */
     def groupByKeySorted[K: Ordering : Encoder, O: Encoder](key: T => K, partitions: Int)(order: T => O, reverse: Boolean): SortedGroupByDataset[K, T] =
       groupByKeySorted(key, Some(partitions))(order, reverse)
 
+    /**
+     * Groups the Dataset and sorts the groups using the specified columns, so we can run
+     * further process the sorted groups. See [[SortedGroupByDataset]] for all the available
+     * functions.
+     *
+     * {{{
+     *   // Enumerate elements in the sorted group
+     *   ds.groupByKeySorted(row => row.getInt(0))(row => row.getInt(1), true)
+     *     .flatMapSortedGroups((key, it) => it.zipWithIndex)
+     * }}}
+     *
+     * @param partitions optional number of partitions
+     * @param key grouping key
+     * @param order sort key
+     * @param reverse sort reverse order
+     */
     def groupByKeySorted[K: Ordering : Encoder, O: Encoder](key: T => K, partitions: Option[Int] = None)(order: T => O, reverse: Boolean = false): SortedGroupByDataset[K, T] = {
       SortedGroupByDataset(ds, key, order, partitions, reverse)
     }
 
-    @scala.annotation.varargs
+    /**
+     * Adds a global continuous row number starting at 1.
+     *
+     * See [[ExtendedDataset#withRowNumbers(String, StorageLevel, UnpersistHandle, Column*)]] for details.
+     */
     def withRowNumbers(order: Column*): DataFrame =
       RowNumbers.withOrderColumns(order: _*).of(ds)
 
-    @scala.annotation.varargs
+    /**
+     * Adds a global continuous row number starting at 1.
+     *
+     * See [[ExtendedDataset#withRowNumbers(String, StorageLevel, UnpersistHandle, Column*)]] for details.
+     */
     def withRowNumbers(rowNumberColumnName: String, order: Column*): DataFrame =
       RowNumbers.withRowNumberColumnName(rowNumberColumnName).withOrderColumns(order).of(ds)
 
-    @scala.annotation.varargs
+    /**
+     * Adds a global continuous row number starting at 1.
+     *
+     * See [[ExtendedDataset#withRowNumbers(String, StorageLevel, UnpersistHandle, Column*)]] for details.
+     */
     def withRowNumbers(storageLevel: StorageLevel, order: Column*): DataFrame =
       RowNumbers.withStorageLevel(storageLevel).withOrderColumns(order).of(ds)
 
-    @scala.annotation.varargs
+    /**
+     * Adds a global continuous row number starting at 1.
+     *
+     * See [[ExtendedDataset#withRowNumbers(String, StorageLevel, UnpersistHandle, Column*)]] for details.
+     */
     def withRowNumbers(unpersistHandle: UnpersistHandle, order: Column*): DataFrame =
       RowNumbers.withUnpersistHandle(unpersistHandle).withOrderColumns(order).of(ds)
 
-    @scala.annotation.varargs
+    /**
+     * Adds a global continuous row number starting at 1.
+     *
+     * See [[ExtendedDataset#withRowNumbers(String, StorageLevel, UnpersistHandle, Column*)]] for details.
+     */
     def withRowNumbers(rowNumberColumnName: String,
                        storageLevel: StorageLevel,
                        order: Column*): DataFrame =
       RowNumbers.withRowNumberColumnName(rowNumberColumnName).withStorageLevel(storageLevel).withOrderColumns(order).of(ds)
 
-    @scala.annotation.varargs
+    /**
+     * Adds a global continuous row number starting at 1.
+     *
+     * See [[ExtendedDataset#withRowNumbers(String, StorageLevel, UnpersistHandle, Column*)]] for details.
+     */
     def withRowNumbers(rowNumberColumnName: String,
                        unpersistHandle: UnpersistHandle,
                        order: Column*): DataFrame =
       RowNumbers.withRowNumberColumnName(rowNumberColumnName).withUnpersistHandle(unpersistHandle).withOrderColumns(order).of(ds)
 
-    @scala.annotation.varargs
+    /**
+     * Adds a global continuous row number starting at 1.
+     *
+     * See [[ExtendedDataset#withRowNumbers(String, StorageLevel, UnpersistHandle, Column*)]] for details.
+     */
     def withRowNumbers(storageLevel: StorageLevel,
                        unpersistHandle: UnpersistHandle,
                        order: Column*): DataFrame =
       RowNumbers.withStorageLevel(storageLevel).withUnpersistHandle(unpersistHandle).withOrderColumns(order).of(ds)
 
-    @scala.annotation.varargs
+    /**
+     * Adds a global continuous row number starting at 1, after sorting rows by the given columns.
+     * When no columns are given, the existing order is used.
+     *
+     * Hence, the following examples are equivalent:
+     * {{{
+     *   ds.withRowNumbers($"a".desc, $"b")
+     *   ds.orderBy($"a".desc, $"b").withRowNumbers()
+     * }}}
+     *
+     * The column name of the column with the row numbers can be set via the `rowNumberColumnName` argument.
+     *
+     * To avoid some known issues optimizing the query plan, this function has to internally call
+     * `Dataset.persist(StorageLevel)` on an intermediate DataFrame. The storage level of that cached
+     * DataFrame can be set via `storageLevel`, where the default is `StorageLevel.MEMORY_AND_DISK`.
+     *
+     * That cached intermediate DataFrame can be un-persisted / un-cached as follows:
+     * {{{
+     *   import uk.co.gresearch.spark.UnpersistHandle
+     *
+     *   val unpersist = UnpersistHandle()
+     *   ds.withRowNumbers(unpersist).show()
+     *   unpersist()
+     * }}}
+     *
+     * @param rowNumberColumnName name of the row number column
+     * @param storageLevel storage level of the cached intermediate DataFrame
+     * @param unpersistHandle handle to un-persist intermediate DataFrame
+     * @param order columns to order dataframe before assigning row numbers
+     * @return dataframe with row numbers
+     */
     def withRowNumbers(rowNumberColumnName: String,
                        storageLevel: StorageLevel,
                        unpersistHandle: UnpersistHandle,

--- a/src/main/scala/uk/co/gresearch/spark/package.scala
+++ b/src/main/scala/uk/co/gresearch/spark/package.scala
@@ -157,44 +157,44 @@ package object spark {
 
     @scala.annotation.varargs
     def withRowNumbers(order: Column*): DataFrame =
-      RowNumbers.of(ds.toDF(), orderColumns=order)
+      RowNumbers.withOrderColumns(order: _*).of(ds)
 
     @scala.annotation.varargs
     def withRowNumbers(rowNumberColumnName: String, order: Column*): DataFrame =
-      RowNumbers.of(ds.toDF(), rowNumberColumnName=rowNumberColumnName, orderColumns=order)
+      RowNumbers.withRowNumberColumnName(rowNumberColumnName).withOrderColumns(order).of(ds)
 
     @scala.annotation.varargs
     def withRowNumbers(storageLevel: StorageLevel, order: Column*): DataFrame =
-      RowNumbers.of(ds.toDF(), storageLevel=storageLevel, orderColumns=order)
+      RowNumbers.withStorageLevel(storageLevel).withOrderColumns(order).of(ds)
 
     @scala.annotation.varargs
     def withRowNumbers(unpersistHandle: UnpersistHandle, order: Column*): DataFrame =
-      RowNumbers.of(ds.toDF(), unpersistHandle=unpersistHandle, orderColumns=order)
+      RowNumbers.withUnpersistHandle(unpersistHandle).withOrderColumns(order).of(ds)
 
     @scala.annotation.varargs
     def withRowNumbers(rowNumberColumnName: String,
                        storageLevel: StorageLevel,
                        order: Column*): DataFrame =
-      RowNumbers.of(ds.toDF(), rowNumberColumnName=rowNumberColumnName, storageLevel=storageLevel, orderColumns=order)
+      RowNumbers.withRowNumberColumnName(rowNumberColumnName).withStorageLevel(storageLevel).withOrderColumns(order).of(ds)
 
     @scala.annotation.varargs
     def withRowNumbers(rowNumberColumnName: String,
                        unpersistHandle: UnpersistHandle,
                        order: Column*): DataFrame =
-      RowNumbers.of(ds.toDF(), rowNumberColumnName=rowNumberColumnName, unpersistHandle=unpersistHandle, orderColumns=order)
+      RowNumbers.withRowNumberColumnName(rowNumberColumnName).withUnpersistHandle(unpersistHandle).withOrderColumns(order).of(ds)
 
     @scala.annotation.varargs
     def withRowNumbers(storageLevel: StorageLevel,
                        unpersistHandle: UnpersistHandle,
                        order: Column*): DataFrame =
-      RowNumbers.of(ds.toDF(), storageLevel=storageLevel, unpersistHandle=unpersistHandle, orderColumns=order)
+      RowNumbers.withStorageLevel(storageLevel).withUnpersistHandle(unpersistHandle).withOrderColumns(order).of(ds)
 
     @scala.annotation.varargs
     def withRowNumbers(rowNumberColumnName: String,
                        storageLevel: StorageLevel,
                        unpersistHandle: UnpersistHandle,
                        order: Column*): DataFrame =
-      RowNumbers.of(ds.toDF(), rowNumberColumnName, storageLevel, unpersistHandle, order)
+      RowNumbers.withRowNumberColumnName(rowNumberColumnName).withStorageLevel(storageLevel).withUnpersistHandle(unpersistHandle).withOrderColumns(order).of(ds)
   }
 
   /**

--- a/src/test/scala/uk/co/gresearch/spark/SparkSuite.scala
+++ b/src/test/scala/uk/co/gresearch/spark/SparkSuite.scala
@@ -330,14 +330,14 @@ class SparkSuite extends AnyFunSuite with SparkTestSession {
 
     val unpersist = UnpersistHandle()
     val df = spark.emptyDataFrame
-    assert(spark.sharedState.cacheManager.lookupCachedData(spark.emptyDataFrame).isDefined === false)
+    assert(cacheManager.lookupCachedData(spark.emptyDataFrame).isDefined === false)
 
     df.cache()
-    assert(spark.sharedState.cacheManager.lookupCachedData(spark.emptyDataFrame).isDefined === true)
+    assert(cacheManager.lookupCachedData(spark.emptyDataFrame).isDefined === true)
 
     unpersist.setDataFrame(df)
     unpersist(blocking = true)
-    assert(spark.sharedState.cacheManager.lookupCachedData(spark.emptyDataFrame).isDefined === false)
+    assert(cacheManager.lookupCachedData(spark.emptyDataFrame).isDefined === false)
 
     // calling this twice does not throw any errors
     unpersist()

--- a/src/test/scala/uk/co/gresearch/spark/SparkSuite.scala
+++ b/src/test/scala/uk/co/gresearch/spark/SparkSuite.scala
@@ -17,6 +17,10 @@
 package uk.co.gresearch.spark
 
 import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.expressions.{Descending, SortOrder}
+import org.apache.spark.sql.functions._
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.storage.StorageLevel.{DISK_ONLY, MEMORY_AND_DISK, MEMORY_ONLY, NONE}
 import org.scalatest.funsuite.AnyFunSuite
 import uk.co.gresearch.ExtendedAny
 import uk.co.gresearch.spark.SparkSuite.Value
@@ -200,6 +204,159 @@ class SparkSuite extends AnyFunSuite with SparkTestSession {
           .or(_.csv(dir.getAbsolutePath))
       )
     }
+  }
+
+  test("global row number preserves order") {
+    doTestWithRowNumbers()(){ df =>
+      assert(df.columns === Seq("id", "rand", "row_number"))
+    }
+  }
+
+  test("global row number respects order") {
+    doTestWithRowNumbers { df => df.repartition(100) }($"id")()
+  }
+
+  test("global row number supports multiple order columns") {
+    doTestWithRowNumbers { df => df.repartition(100) }($"id", $"rand", rand())()
+  }
+
+  test("global row number allows desc order") {
+    doTestWithRowNumbers { df => df.repartition(100) }($"id".desc)()
+  }
+
+  Seq(MEMORY_AND_DISK, MEMORY_ONLY, DISK_ONLY).foreach { level =>
+    test(s"global row number with $level") {
+      doTestWithRowNumbers(storageLevel = level)($"id")()
+    }
+  }
+
+  Seq(MEMORY_AND_DISK, MEMORY_ONLY, DISK_ONLY).foreach { level =>
+    test(s"global row number allows to unpersist with $level") {
+      val cacheManager = spark.sharedState.cacheManager
+      cacheManager.clearCache()
+      assert(cacheManager.isEmpty === true)
+
+      val unpersist = UnpersistHandle()
+      doTestWithRowNumbers(storageLevel = level, unpersistHandle = unpersist)($"id")()
+      assert(cacheManager.isEmpty === false)
+      unpersist(true)
+      assert(cacheManager.isEmpty === true)
+    }
+  }
+
+  test("global row number with existing row_number column") {
+    // this overwrites the existing column 'row_number' (formerly 'rand') with the row numbers
+    doTestWithRowNumbers { df => df.withColumnRenamed("rand", "row_number") }(){ df =>
+      assert(df.columns === Seq("id", "row_number"))
+    }
+  }
+
+  test("global row number with custom row_number column") {
+    // this puts the row numbers in the column "row", which is not the default column name
+    doTestWithRowNumbers(df => df.withColumnRenamed("rand", "row_number"),
+      rowNumberColumnName = "row" )(){ df =>
+      assert(df.columns === Seq("id", "row_number", "row"))
+    }
+  }
+
+  test("global row number with internal column names") {
+    val cols = Seq("mono_id", "partition_id", "local_row_number", "max_local_row_number",
+      "cum_row_numbers", "partition_offset")
+    var prefix: String = null
+
+    doTestWithRowNumbers { df =>
+      prefix = distinctPrefixFor(df.columns)
+      cols.foldLeft(df){ (df, name) => df.withColumn(prefix + name, rand()) }
+    }(){ df =>
+      assert(df.columns === Seq("id", "rand") ++ cols.map(prefix + _) :+ "row_number")
+    }
+  }
+
+  def doTestWithRowNumbers(transform: DataFrame => DataFrame = identity,
+                           rowNumberColumnName: String = "row_number",
+                           storageLevel: StorageLevel = MEMORY_AND_DISK,
+                           unpersistHandle: UnpersistHandle = UnpersistHandle.Noop)
+                          (columns: Column*)
+                          (handle: DataFrame => Unit = identity[DataFrame]): Unit = {
+    val partitions = 10
+    val rowsPerPartition = 1000
+    val rows = partitions * rowsPerPartition
+    assert(partitions > 1)
+    assert(rowsPerPartition > 1)
+
+    val df = spark.range(1, rows + 1, 1, partitions)
+      .withColumn("rand", rand())
+      .transform(transform)
+      .withRowNumbers(
+        rowNumberColumnName=rowNumberColumnName,
+        storageLevel=storageLevel,
+        unpersistHandle=unpersistHandle,
+        columns: _*)
+      .cache()
+
+    try {
+      // testing with descending order is only supported for a single column
+      val desc = columns.map(_.expr) match {
+        case Seq(SortOrder(_, Descending, _, _)) => true
+        case _ => false
+      }
+
+      // assert row numbers are correct
+      assertRowNumbers(df, rows, desc, rowNumberColumnName)
+      handle(df)
+    } finally {
+      // always unpersist
+      df.unpersist(true)
+    }
+  }
+
+  def assertRowNumbers(df: DataFrame, rows: Int, desc: Boolean, rowNumberColumnName: String): Unit = {
+    val expect = if (desc) {
+      $"id" === (lit(rows) - col(rowNumberColumnName) + 1)
+    } else {
+      $"id" === col(rowNumberColumnName)
+    }
+
+    val correctRowNumbers = df.where(expect).count()
+    val incorrectRowNumbers = df.where(! expect).count()
+    assert(correctRowNumbers === rows)
+    assert(incorrectRowNumbers === 0)
+  }
+
+  test("UnpersistHandle does unpersit set DataFrame") {
+    val cacheManager = spark.sharedState.cacheManager
+    cacheManager.clearCache()
+    assert(cacheManager.isEmpty === true)
+
+    val unpersist = UnpersistHandle()
+    val df = spark.emptyDataFrame
+    assert(spark.sharedState.cacheManager.lookupCachedData(spark.emptyDataFrame).isDefined === false)
+
+    df.cache()
+    assert(spark.sharedState.cacheManager.lookupCachedData(spark.emptyDataFrame).isDefined === true)
+
+    unpersist.setDataFrame(df)
+    unpersist(blocking = true)
+    assert(spark.sharedState.cacheManager.lookupCachedData(spark.emptyDataFrame).isDefined === false)
+
+    // calling this twice does not throw any errors
+    unpersist()
+  }
+
+  test("UnpersistHandle throws on unpersist if no DataFrame is set") {
+    val unpersist = UnpersistHandle()
+    assert(intercept[IllegalStateException] { unpersist() }.getMessage === s"DataFrame has to be set first")
+  }
+
+  test("UnpersistHandle throws on unpersist with blocking if no DataFrame is set") {
+    val unpersist = UnpersistHandle()
+    assert(intercept[IllegalStateException] { unpersist(blocking = true) }.getMessage === s"DataFrame has to be set first")
+  }
+
+  test("UnpersistHandle throws on setting DataFrame twice") {
+    val unpersist = UnpersistHandle()
+    unpersist.setDataFrame(spark.emptyDataFrame)
+    assert(intercept[IllegalStateException] { unpersist.setDataFrame(spark.emptyDataFrame) }.getMessage === s"DataFrame has been set already. It cannot be reused once used with withRowNumbers.")
   }
 
 }

--- a/src/test/scala/uk/co/gresearch/spark/diff/DiffSuite.scala
+++ b/src/test/scala/uk/co/gresearch/spark/diff/DiffSuite.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Dataset, Encoders, Row}
 import org.scalatest.funsuite.AnyFunSuite
-import uk.co.gresearch.spark.SparkTestSession
+import uk.co.gresearch.spark.{SparkTestSession, distinctPrefixFor, _}
 
 case class Empty()
 case class Value(id: Int, value: Option[String])
@@ -237,11 +237,14 @@ class DiffSuite extends AnyFunSuite with SparkTestSession {
     )
   )
 
-  test("distinct string for") {
-    assert(Diff.distinctStringNameFor(Seq.empty[String]) === "_")
-    assert(Diff.distinctStringNameFor(Seq("a")) === "__")
-    assert(Diff.distinctStringNameFor(Seq("abc")) === "____")
-    assert(Diff.distinctStringNameFor(Seq("a", "bc", "def")) === "____")
+  test("distinct prefix for") {
+    assert(distinctPrefixFor(Seq.empty[String]) === "_")
+    assert(distinctPrefixFor(Seq("a")) === "_")
+    assert(distinctPrefixFor(Seq("abc")) === "_")
+    assert(distinctPrefixFor(Seq("a", "bc", "def")) === "_")
+    assert(distinctPrefixFor(Seq("_a")) === "__")
+    assert(distinctPrefixFor(Seq("_abc")) === "__")
+    assert(distinctPrefixFor(Seq("a", "_bc", "__def")) === "___")
   }
 
   test("diff dataframe with duplicate columns") {


### PR DESCRIPTION
Adds global row number to Dataset: [ROW_NUMBER.md](https://github.com/G-Research/spark-extension/blob/branch-add-row-number/ROW_NUMBER.md)

Can be tested as [2.2.0-3.2-SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/uk/co/gresearch/spark/spark-extension_2.12/2.2.0-3.2-SNAPSHOT/) using repo https://oss.sonatype.org/content/repositories/snapshots.