### PR TITLE
Replace usage of deprecated DataFrame.sql_ctx with sparkSession

### DIFF
--- a/python/gresearch/spark/__init__.py
+++ b/python/gresearch/spark/__init__.py
@@ -55,7 +55,7 @@ def histogram(self: DataFrame,
 
     hist = _get_scala_object(jvm, 'uk.co.gresearch.spark.Histogram')
     jdf = hist.of(self._jdf, _to_seq(jvm, thresholds), value_column, _to_seq(jvm, aggregate_columns))
-    return DataFrame(jdf, self.sql_ctx)
+    return DataFrame(jdf, self.sparkSession)
 
 
 DataFrame.histogram = histogram
@@ -102,7 +102,7 @@ def with_row_numbers(self: DataFrame,
         .withOrderColumns(jcols) \
         .of(self._jdf)
 
-    return DataFrame(jdf, self.sql_ctx)
+    return DataFrame(jdf, self.sparkSession)
 
 
 DataFrame.with_row_numbers = with_row_numbers

--- a/python/gresearch/spark/diff/__init__.py
+++ b/python/gresearch/spark/diff/__init__.py
@@ -424,7 +424,7 @@ class Differ:
         jvm = left._sc._jvm
         jdiffer = self._to_java(jvm)
         jdf = jdiffer.diff(left._jdf, right._jdf, _to_seq(jvm, list(id_columns)))
-        return DataFrame(jdf, left.sql_ctx)
+        return DataFrame(jdf, left.sparkSession)
 
 
 def diff(self: DataFrame, other: DataFrame, *id_columns: str) -> DataFrame:

--- a/python/gresearch/spark/diff/__init__.py
+++ b/python/gresearch/spark/diff/__init__.py
@@ -12,9 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from enum import Enum
+from typing import Union
+
 from py4j.java_gateway import JavaObject, JVMView
 from pyspark.sql import DataFrame
-from enum import Enum
+
 from gresearch.spark import _to_seq
 
 
@@ -424,7 +427,7 @@ class Differ:
         jvm = left._sc._jvm
         jdiffer = self._to_java(jvm)
         jdf = jdiffer.diff(left._jdf, right._jdf, _to_seq(jvm, list(id_columns)))
-        return DataFrame(jdf, left.sparkSession)
+        return DataFrame(jdf, left.session_or_ctx())
 
 
 def diff(self: DataFrame, other: DataFrame, *id_columns: str) -> DataFrame:


### PR DESCRIPTION
Fixes this deprecation warning:
```
pyspark/sql/dataframe.py:148: UserWarning: DataFrame.sql_ctx is an internal property,
and will be removed in future releases. Use DataFrame.sparkSession instead.
```
The following warning was an indirect consequence, which also gets fixed:
```
pyspark/sql/dataframe.py:127: UserWarning: DataFrame constructor is internal. Do not directly use it.
```