### PR TITLE
Bringing back Spark 3.0 and 3.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - spark-compat-version: '3.0'
+            spark-version: '3.0.3'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.10'
+          - spark-compat-version: '3.1'
+            spark-version: '3.1.3'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.10'
           - spark-compat-version: '3.2'
             spark-version: '3.2.4'
             scala-compat-version: '2.12'
@@ -121,6 +129,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - spark-compat-version: '3.0'
+            spark-version: '3.0.3'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.10'
+          - spark-compat-version: '3.1'
+            spark-version: '3.1.3'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.10'
           - spark-compat-version: '3.2'
             spark-version: '3.2.4'
             scala-compat-version: '2.12'
@@ -162,6 +178,14 @@ jobs:
           - spark-compat-version: '3.3'
             spark-patch-version: '3'
         include:
+          - spark-compat-version: '3.0'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.10'
+            spark-patch-version: '3'
+          - spark-compat-version: '3.1'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.10'
+            spark-patch-version: '3'
           - spark-compat-version: '3.2'
             scala-compat-version: '2.12'
             scala-version: '2.12.15'
@@ -220,6 +244,16 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
 
         include:
+          - spark-compat-version: '3.0'
+            spark-version: '3.0.3'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.10'
+            python-version: '3.8'
+          - spark-compat-version: '3.1'
+            spark-version: '3.1.3'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.10'
+            python-version: '3.8'
           - spark-compat-version: '3.2'
             spark-version: '3.2.4'
             scala-compat-version: '2.12'

--- a/python/requirements-3.0_2.12.txt
+++ b/python/requirements-3.0_2.12.txt
@@ -1,0 +1,3 @@
+py4j
+# keep in-sync with pom.xml
+pyspark==3.0.3

--- a/python/requirements-3.1_2.12.txt
+++ b/python/requirements-3.1_2.12.txt
@@ -1,0 +1,3 @@
+py4j
+# keep in-sync with pom.xml
+pyspark==3.1.3

--- a/release.sh
+++ b/release.sh
@@ -54,6 +54,8 @@ then
 fi
 
 # testing all versions
+./set-version.sh 3.0.3 2.12.10 && mvn clean deploy && ./build-whl.sh && ./test-release.sh || exit 1
+./set-version.sh 3.1.3 2.12.10 && mvn clean deploy && ./build-whl.sh && ./test-release.sh || exit 1
 ./set-version.sh 3.2.4 2.12.15 && mvn clean deploy && ./build-whl.sh && ./test-release.sh || exit 1
 ./set-version.sh 3.3.2 2.12.15 && mvn clean deploy && ./build-whl.sh && ./test-release.sh || exit 1
 ./set-version.sh 3.4.0 2.12.17 && mvn clean deploy && ./build-whl.sh && ./test-release.sh || exit 1
@@ -98,6 +100,8 @@ echo
 # create release
 echo "Creating release packages"
 mkdir -p python/pyspark/jars/
+./set-version.sh 3.0.3 2.12.10 && mvn clean deploy -Dsign && mvn nexus-staging:release && ./build-whl.sh
+./set-version.sh 3.1.3 2.12.10 && mvn clean deploy -Dsign && mvn nexus-staging:release && ./build-whl.sh
 ./set-version.sh 3.2.4 2.12.15 && mvn clean deploy -Dsign && mvn nexus-staging:release && ./build-whl.sh
 ./set-version.sh 3.3.2 2.12.15 && mvn clean deploy -Dsign && mvn nexus-staging:release && ./build-whl.sh
 ./set-version.sh 3.4.0 2.12.17 && mvn clean deploy -Dsign && mvn nexus-staging:release && ./build-whl.sh

--- a/src/main/scala-spark-3.0/uk/co/gresearch/spark/BinaryLikeWithNewChildrenInternal.scala
+++ b/src/main/scala-spark-3.0/uk/co/gresearch/spark/BinaryLikeWithNewChildrenInternal.scala
@@ -1,0 +1,21 @@
+package uk.co.gresearch.spark
+
+import org.apache.spark.sql.catalyst.trees.TreeNode
+
+/**
+ * Spark version specific trait that back-ports BinaryLike[T].withNewChildrenInternal(T, T)
+ * to Spark 3.0 and 3.1. This is empty in Spark 3.2 and beyond.
+ */
+trait BinaryLikeWithNewChildrenInternal[T <: TreeNode[T]] {
+  self: TreeNode[T] =>
+
+  /**
+   * Method `withNewChildrenInternal` is required for Spark 3.2 and beyond.
+   * Before, `withNewChildren` is called by Spark, which uses `makeCopy`, which
+   *   "Must be overridden by child classes that have constructor arguments
+   *    that are not present in the productIterator.",
+   * which is not true for where BinaryLikeWithNewChildrenInternal is used here.
+   * So nothing need to be overridden.
+   */
+  protected def withNewChildrenInternal(newLeft: T, newRight: T): T
+}

--- a/src/main/scala-spark-3.0/uk/co/gresearch/spark/parquet/SplitFile.scala
+++ b/src/main/scala-spark-3.0/uk/co/gresearch/spark/parquet/SplitFile.scala
@@ -1,0 +1,1 @@
+../../../../../../scala-spark-3.2/uk/co/gresearch/spark/parquet/SplitFile.scala

--- a/src/main/scala-spark-3.1/uk/co/gresearch/spark/BinaryLikeWithNewChildrenInternal.scala
+++ b/src/main/scala-spark-3.1/uk/co/gresearch/spark/BinaryLikeWithNewChildrenInternal.scala
@@ -1,0 +1,21 @@
+package uk.co.gresearch.spark
+
+import org.apache.spark.sql.catalyst.trees.TreeNode
+
+/**
+ * Spark version specific trait that back-ports BinaryLike[T].withNewChildrenInternal(T, T)
+ * to Spark 3.0 and 3.1. This is empty in Spark 3.2 and beyond.
+ */
+trait BinaryLikeWithNewChildrenInternal[T <: TreeNode[T]] {
+  self: TreeNode[T] =>
+
+  /**
+   * Method `withNewChildrenInternal` is required for Spark 3.2 and beyond.
+   * Before, `withNewChildren` is called by Spark, which uses `makeCopy`, which
+   *   "Must be overridden by child classes that have constructor arguments
+   *    that are not present in the productIterator.",
+   * which is not true for where BinaryLikeWithNewChildrenInternal is used here.
+   * So nothing need to be overridden.
+   */
+  protected def withNewChildrenInternal(newLeft: T, newRight: T): T
+}

--- a/src/main/scala-spark-3.1/uk/co/gresearch/spark/parquet/SplitFile.scala
+++ b/src/main/scala-spark-3.1/uk/co/gresearch/spark/parquet/SplitFile.scala
@@ -1,0 +1,1 @@
+../../../../../../scala-spark-3.2/uk/co/gresearch/spark/parquet/SplitFile.scala

--- a/src/main/scala-spark-3.2/uk/co/gresearch/spark/BinaryLikeWithNewChildrenInternal.scala
+++ b/src/main/scala-spark-3.2/uk/co/gresearch/spark/BinaryLikeWithNewChildrenInternal.scala
@@ -1,0 +1,7 @@
+package uk.co.gresearch.spark
+
+/**
+ * Spark version specific trait that back-ports BinaryLike[T].withNewChildrenInternal(T, T)
+ * to Spark 3.0 and 3.1. This is empty in Spark 3.2 and beyond.
+ */
+trait BinaryLikeWithNewChildrenInternal[T]

--- a/src/main/scala-spark-3.3/uk/co/gresearch/spark/BinaryLikeWithNewChildrenInternal.scala
+++ b/src/main/scala-spark-3.3/uk/co/gresearch/spark/BinaryLikeWithNewChildrenInternal.scala
@@ -1,0 +1,7 @@
+package uk.co.gresearch.spark
+
+/**
+ * Spark version specific trait that back-ports BinaryLike[T].withNewChildrenInternal(T, T)
+ * to Spark 3.0 and 3.1. This is empty in Spark 3.2 and beyond.
+ */
+trait BinaryLikeWithNewChildrenInternal[T]

--- a/src/main/scala-spark-3.4/uk/co/gresearch/spark/BinaryLikeWithNewChildrenInternal.scala
+++ b/src/main/scala-spark-3.4/uk/co/gresearch/spark/BinaryLikeWithNewChildrenInternal.scala
@@ -1,0 +1,7 @@
+package uk.co.gresearch.spark
+
+/**
+ * Spark version specific trait that back-ports BinaryLike[T].withNewChildrenInternal(T, T)
+ * to Spark 3.0 and 3.1. This is empty in Spark 3.2 and beyond.
+ */
+trait BinaryLikeWithNewChildrenInternal[T]

--- a/src/main/scala-spark-3.5/uk/co/gresearch/spark/BinaryLikeWithNewChildrenInternal.scala
+++ b/src/main/scala-spark-3.5/uk/co/gresearch/spark/BinaryLikeWithNewChildrenInternal.scala
@@ -1,0 +1,7 @@
+package uk.co.gresearch.spark
+
+/**
+ * Spark version specific trait that back-ports BinaryLike[T].withNewChildrenInternal(T, T)
+ * to Spark 3.0 and 3.1. This is empty in Spark 3.2 and beyond.
+ */
+trait BinaryLikeWithNewChildrenInternal[T]

--- a/src/main/scala/uk/co/gresearch/spark/diff/comparator/EquivDiffComparator.scala
+++ b/src/main/scala/uk/co/gresearch/spark/diff/comparator/EquivDiffComparator.scala
@@ -7,6 +7,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCo
 import org.apache.spark.sql.catalyst.expressions.{BinaryExpression, BinaryOperator, Expression}
 import org.apache.spark.sql.types.{BooleanType, DataType}
 import org.apache.spark.sql.{Column, Encoder}
+import uk.co.gresearch.spark.BinaryLikeWithNewChildrenInternal
 
 trait EquivDiffComparator[T] extends DiffComparator {
   val equiv: math.Equiv[T]
@@ -45,7 +46,7 @@ object EquivDiffComparator {
   }
 }
 
-private trait EquivExpression[T] extends BinaryExpression {
+private trait EquivExpression[T] extends BinaryExpression with BinaryLikeWithNewChildrenInternal[Expression] {
   val equiv: math.Equiv[T]
 
   override def nullable: Boolean = false


### PR DESCRIPTION
partially reverts commits 8bd4cd3beb97e7bfd89ed63fb5d81b19076e57fe and b0a82fbc6d1940bfb9360af6307a36992ec13e69.

Someone might still want next releases for 3.0 and 3.1.