### PR TITLE
Install the specific pyspark version, not the dependency of the whl

### DIFF
--- a/.github/actions/build-whl/action.yml
+++ b/.github/actions/build-whl/action.yml
@@ -62,7 +62,8 @@ runs:
   - name: Test whl
     run: |
       twine check python/dist/*
-      pip install python/dist/*.whl --find-links https://archive.apache.org/dist/spark/spark-3.5.0
+      pip install pyspark==${{ inputs.spark-version }} --find-links https://archive.apache.org/dist/spark/spark-3.5.0
+      pip install python/dist/*.whl
       python test-release.py
     shell: bash
 


### PR DESCRIPTION
Tests build whl against specific Spark version, not latest.