### PR TITLE
CI: Add linter check for scala

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
     name: "Linting"
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - uses: jrouly/scalafmt-native-action@v2
         with:
           version: '3.7.14'

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,7 +1,7 @@
 version = 3.7.14
 
 runner.dialect = scala213
-  rewrite.trailingCommas.style = keep
+rewrite.trailingCommas.style = keep
 
 maxColumn = 120
 


### PR DESCRIPTION
The goal of this PR is to enable CI to have linter enabled and basic rules defined in `.github/workflows/linter.yml` 

