### PR TITLE
release spak-extension

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  workflow_run:
+    branches: "v*"
+    workflows: ["CI"]
+    types:
+      - completed
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: |
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.repository_owner == 'G-Research'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: "${{ github.event.workflow_run.head_branch }}"
+          tag_name: ${{ github.event.workflow_run.head_branch }}


### PR DESCRIPTION
The goal of this PR is to have basic release process for spark-extension
Following examples are mentioned below on forked repo

Pushing a tag spark-extension-1.0.2-test triggered a workflow CI: https://github.com/ljubon/spark-extension/actions/runs/5820714977

As CI workflow finished with success, Rlease triggered after CI workflow: https://github.com/ljubon/spark-extension/actions/runs/5820716615