### PR TITLE
Fix version order to find latest version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,7 +25,7 @@ jobs:
           echo "major-version: ${version/.*/}"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "major-version=${version/.*/}" >> "$GITHUB_OUTPUT"
-          release_version=$(git tag | tail -n1 | sed "s/^v//")
+          release_version=$(git tag | grep "^v" | sort --version-sort | tail -n1 | sed "s/^v//")
           echo "release-version: $release_version"
           echo "release-major-version: ${release_version/.*/}"
           echo "release-version=$release_version" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Without, version `2.10.0` comes before `2.9.0`, so the latter is wrongly picked as the latest version.