### PR TITLE
Provide groupByKey shortcuts for groupBy.as

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ i.doThis()
  .doMore()
 ```
 
-**[Shortcut for groupBy.as](https://github.com/G-Research/spark-extension/pull/213#issue-2032837105)**: Calling `Dataset.groupBy(...).as[K, T]`
-should be preferred over calling `Dataset.groupByKey(...)` whenever possible. The former allows Catalyst to exploit
+**[Shortcut for groupBy.as](https://github.com/G-Research/spark-extension/pull/213#issue-2032837105)**: Calling `Dataset.groupBy(Column*).as[K, T]`
+should be preferred over calling `Dataset.groupByKey(V => K)` whenever possible. The former allows Catalyst to exploit
 existing partitioning and ordering of the Dataset, while the latter hides from Catalyst which columns are used to create the keys.
 This can have a significant performance penalty.
 
-The new column-expression-based `groupByKey` methods make it easier to group by a column expression key. Instead of
+The new column-expression-based `groupByKey[K](Column*)` method makes it easier to group by a column expression key. Instead of
 
     ds.groupBy($"id").as[Int, V]
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ i.doThis()
  .doMore()
 ```
 
+**[Shortcut for groupBy.as](https://github.com/G-Research/spark-extension/pull/213#issue-2032837105)**: Calling `Dataset.groupBy(...).as[K, T]`
+should be preferred over calling `Dataset.groupByKey(...)` whenever possible. The former allows Catalyst to exploit
+existing partitioning and ordering of the Dataset, while the latter hides from Catalyst which columns are used to create the keys.
+This can have a significant performance penalty.
+
+The new column-expression-based `groupByKey` methods make it easier to group by a column expression key. Instead of
+
+    ds.groupBy($"id").as[Int, V]
+
+use:
+
+    ds.groupByKey[Int]($"id")
+
 **Backticks:** `backticks(string: String, strings: String*): String)`: Encloses the given column name with backticks (`` ` ``) when needed.
 This is a handy way to ensure column names with special characters like dots (`.`) work with `col()` or `select()`.
 


### PR DESCRIPTION
This provides shortcuts for `groupBy(...).as[...]` that make it easier to use column-based `groupByKey`.

Calling `Dataset.groupBy(...).as[K, T]` should be preferred over calling `Dataset.groupByKey(...)` whenever possible. The former allows Catalyst to exploit existing partitioning and ordering of the Dataset, while the latter hides from Catalyst which columns are used to create the keys.

_When the dataset is already partitioned and ordered by the grouping columns, `Dataset.groupByKey(...)` will repartition and order the entire dataset again._

Example:

Calling `ds.groupByKey(_.id)` hides from Catalyst that column `id` is the grouping key, while `ds.groupBy($"id").as[Int, V]` tells Catalyst that `ds` is to be grouped by (partitioned and ordered by) column `id`.

The new column-based `groupByKey` methods make it easier for users to find a way to express the grouping by expressions. Looking at the `Dataset` API, the user finds `groupByKey` with `Column`. The existing `groupBy` method returns a `RelationalGroupedDataset`, which provides the `as[K, V]` method, which allows for the same semantics, but is difficult to find.

The new column-based `groupByKey` methods further do not require the user to specify the type `V` of the original `Dataset[V]`, as `groupByKey` has access to the type / encoder:

    ds.groupBy($"id").as[Int, V]

vs.

    ds.groupByKey[Int]($"id")
