### PR TITLE
Fix skipped poetry install tests

### DIFF
--- a/.github/actions/test-python/action.yml
+++ b/.github/actions/test-python/action.yml
@@ -78,18 +78,23 @@ runs:
 
   - name: Prepare poetry tests
     run: |
+      # install poetry in venv
       python -m venv .poetry-venv
       .poetry-venv/bin/python -m pip install poetry
+      # env var needed by poetry tests
+      echo "POETRY_PYTHON=$PWD/.poetry-venv/bin/python" | tee -a "$GITHUB_ENV"
+
+      # clone example poetry project
       git clone https://github.com/Textualize/rich.git .rich
       cd .rich
       git reset --hard 20024635c06c22879fd2fd1e380ec4cccd9935dd
+      # env var needed by poetry tests
+      echo "RICH_SOURCES=$PWD" | tee -a "$GITHUB_ENV"
     shell: bash
 
   - name: Python Unit Tests
     env:
       PYTHONPATH: python:python/test
-      RICH_SOURCES: .rich
-      POETRY_PYTHON: .poetry-venv/bin/python
     run: |
       python -m pytest python/test --junit-xml test-results/pytest-$(date +%s.%N)-$RANDOM.xml
     shell: bash

--- a/.github/actions/test-python/action.yml
+++ b/.github/actions/test-python/action.yml
@@ -104,6 +104,8 @@ runs:
     shell: bash
 
   - name: Python Integration Tests
+    env:
+      PYTHONPATH: python:python/test
     run: |
       find python/test -name 'test*.py' > tests
       while read test

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -25,10 +25,6 @@ jobs:
           name_is_regexp: true
           path: artifacts
 
-      - name: artifacts
-        run: find artifacts | sort
-        shell: bash
-
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:

--- a/python/test/spark_common.py
+++ b/python/test/spark_common.py
@@ -15,9 +15,9 @@
 import contextlib
 import logging
 import os
-import subprocess
 import sys
 import unittest
+from pathlib import Path
 
 from pyspark import SparkConf
 from pyspark.sql import SparkSession
@@ -38,12 +38,13 @@ def spark_session():
 class SparkTest(unittest.TestCase):
 
     @staticmethod
-    def main():
+    def main(file: str):
         if len(sys.argv) == 2:
             # location to store test results provided, this requires package unittest-xml-reporting
             import xmlrunner
 
             unittest.main(
+                module=f'test.{Path(file).name[:-3]}',
                 testRunner=xmlrunner.XMLTestRunner(output=sys.argv[1]),
                 argv=sys.argv[:1],
                 # these make sure that some options that are not applicable

--- a/python/test/test_diff.py
+++ b/python/test/test_diff.py
@@ -378,4 +378,4 @@ class DiffTest(SparkTest):
 
 
 if __name__ == '__main__':
-    SparkTest.main()
+    SparkTest.main(__file__)

--- a/python/test/test_histogram.py
+++ b/python/test/test_histogram.py
@@ -49,4 +49,4 @@ class HistogramTest(SparkTest):
 
 
 if __name__ == '__main__':
-    SparkTest.main()
+    SparkTest.main(__file__)

--- a/python/test/test_job_description.py
+++ b/python/test/test_job_description.py
@@ -67,4 +67,4 @@ class JobDescriptionTest(SparkTest):
 
 
 if __name__ == '__main__':
-    SparkTest.main()
+    SparkTest.main(__file__)

--- a/python/test/test_package.py
+++ b/python/test/test_package.py
@@ -260,4 +260,4 @@ class PackageTest(SparkTest):
 
 
 if __name__ == '__main__':
-    SparkTest.main()
+    SparkTest.main(__file__)

--- a/python/test/test_package.py
+++ b/python/test/test_package.py
@@ -238,7 +238,7 @@ class PackageTest(SparkTest):
         expected = [Row("👍")] * 10
         self.assertEqual(expected, actual)
 
-    @skipIf(__version__.startswith('3.0.'), 'install_pip_package not supported for Spark 3.0')
+    @skipIf(__version__.startswith('3.0.'), 'install_poetry_project not supported for Spark 3.0')
     # provide an environment variable with path to the python binary of a virtual env that has poetry installed
     @skipIf(POETRY_PYTHON_ENV not in os.environ, f'Environment variable {POETRY_PYTHON_ENV} pointing to '
                                                  f'virtual env python with poetry required')

--- a/python/test/test_parquet.py
+++ b/python/test/test_parquet.py
@@ -54,4 +54,4 @@ class ParquetTest(SparkTest):
 
 
 if __name__ == '__main__':
-    SparkTest.main()
+    SparkTest.main(__file__)

--- a/python/test/test_row_number.py
+++ b/python/test/test_row_number.py
@@ -132,4 +132,4 @@ class RowNumberTest(SparkTest):
 
 
 if __name__ == '__main__':
-    SparkTest.main()
+    SparkTest.main(__file__)


### PR DESCRIPTION
It looks like two poetry tests are skip across all of CI matrix strategy: https://github.com/G-Research/spark-extension/pull/216#issuecomment-1853352948

This PR is to fix this.

Tests that ran through `spark-submit` 1) had were missing the module name, so appeared under a different name, and 2) they were missing the environment variables, so they were skipped. Both is fixed.