### PR TITLE
Move python dependencies into tests_require

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -35,7 +35,7 @@ setup(
     author="Enrico Minack",
     author_email="github@enrico.minack.dev",
     url="https://github.com/G-Research/spark-extension",
-    install_requires=[f"pyspark>={spark_compat_version},<4", "py4j"],
+    tests_require=[f"pyspark~={spark_compat_version}.0", "py4j"],
     packages=[
         "gresearch",
         "gresearch.spark",


### PR DESCRIPTION
Otherwise, installing pyspark-extension also installs pyspark, Usually, the package is used in a PySpark environment, so that is not desired. Further, PySpark version is pinned to the Spark compat version.