### PR TITLE
Check that the Java / Scala package is installed when needed

### DIFF
--- a/python/gresearch/spark/diff/__init__.py
+++ b/python/gresearch/spark/diff/__init__.py
@@ -20,7 +20,7 @@ from py4j.java_gateway import JavaObject, JVMView
 from pyspark.sql import DataFrame
 from pyspark.sql.types import DataType
 
-from gresearch.spark import _to_seq, _to_map
+from gresearch.spark import _jvm, _to_seq, _to_map
 from gresearch.spark.diff.comparator import DiffComparator, DiffComparators, DefaultDiffComparator
 
 
@@ -34,7 +34,7 @@ class DiffMode(Enum):
     Default = "Default"
 
     def _to_java(self, jvm: JVMView) -> JavaObject:
-        return jvm.uk.co.gresearch.spark.diff.DiffMode.withNameOption(self.name).get()
+        return _jvm(jvm).uk.co.gresearch.spark.diff.DiffMode.withNameOption(self.name).get()
 
 
 @dataclass(frozen=True)
@@ -233,7 +233,7 @@ class DiffOptions:
         return dataclasses.replace(self, column_name_comparators=column_name_comparators)
 
     def _to_java(self, jvm: JVMView) -> JavaObject:
-        return jvm.uk.co.gresearch.spark.diff.DiffOptions(
+        return _jvm(jvm).uk.co.gresearch.spark.diff.DiffOptions(
             self.diff_column,
             self.left_column_prefix,
             self.right_column_prefix,
@@ -268,7 +268,7 @@ class Differ:
 
     def _to_java(self, jvm: JVMView) -> JavaObject:
         jdo = self._options._to_java(jvm)
-        return jvm.uk.co.gresearch.spark.diff.Differ(jdo)
+        return _jvm(jvm).uk.co.gresearch.spark.diff.Differ(jdo)
 
     def diff(self, left: DataFrame, right: DataFrame, *id_columns: str) -> DataFrame:
         """

--- a/python/gresearch/spark/diff/comparator/__init__.py
+++ b/python/gresearch/spark/diff/comparator/__init__.py
@@ -20,6 +20,8 @@ from py4j.java_gateway import JVMView, JavaObject
 
 from pyspark.sql.types import DataType
 
+from gresearch.spark import _jvm
+
 
 class DiffComparator(abc.ABC):
     @abc.abstractmethod
@@ -55,12 +57,12 @@ class DiffComparators:
 
 class DefaultDiffComparator(DiffComparator):
     def _to_java(self, jvm: JVMView) -> JavaObject:
-        return jvm.uk.co.gresearch.spark.diff.DiffComparators.default()
+        return _jvm(jvm).uk.co.gresearch.spark.diff.DiffComparators.default()
 
 
 class NullSafeEqualDiffComparator(DiffComparator):
     def _to_java(self, jvm: JVMView) -> JavaObject:
-        return jvm.uk.co.gresearch.spark.diff.DiffComparators.nullSafeEqual()
+        return _jvm(jvm).uk.co.gresearch.spark.diff.DiffComparators.nullSafeEqual()
 
 
 @dataclass(frozen=True)
@@ -82,7 +84,7 @@ class EpsilonDiffComparator(DiffComparator):
         return dataclasses.replace(self, inclusive=False)
 
     def _to_java(self, jvm: JVMView) -> JavaObject:
-        return jvm.uk.co.gresearch.spark.diff.comparator.EpsilonDiffComparator(self.epsilon, self.relative, self.inclusive)
+        return _jvm(jvm).uk.co.gresearch.spark.diff.comparator.EpsilonDiffComparator(self.epsilon, self.relative, self.inclusive)
 
 
 @dataclass(frozen=True)
@@ -90,7 +92,7 @@ class StringDiffComparator(DiffComparator):
     whitespace_agnostic: bool
 
     def _to_java(self, jvm: JVMView) -> JavaObject:
-        return jvm.uk.co.gresearch.spark.diff.DiffComparators.string(self.whitespace_agnostic)
+        return _jvm(jvm).uk.co.gresearch.spark.diff.DiffComparators.string(self.whitespace_agnostic)
 
 
 @dataclass(frozen=True)
@@ -106,7 +108,7 @@ class DurationDiffComparator(DiffComparator):
 
     def _to_java(self, jvm: JVMView) -> JavaObject:
         jduration = jvm.java.time.Duration.parse(self.duration)
-        return jvm.uk.co.gresearch.spark.diff.comparator.DurationDiffComparator(jduration, self.inclusive)
+        return _jvm(jvm).uk.co.gresearch.spark.diff.comparator.DurationDiffComparator(jduration, self.inclusive)
 
 
 @dataclass(frozen=True)
@@ -121,4 +123,4 @@ class MapDiffComparator(DiffComparator):
         jfromjson = jvm.org.apache.spark.sql.types.__getattr__("DataType$").__getattr__("MODULE$").fromJson
         jkeytype = jfromjson(self.key_type.json())
         jvaluetype = jfromjson(self.value_type.json())
-        return jvm.uk.co.gresearch.spark.diff.DiffComparators.map(jkeytype, jvaluetype, self.key_order_sensitive)
+        return _jvm(jvm).uk.co.gresearch.spark.diff.DiffComparators.map(jkeytype, jvaluetype, self.key_order_sensitive)

--- a/python/gresearch/spark/parquet/__init__.py
+++ b/python/gresearch/spark/parquet/__init__.py
@@ -17,12 +17,12 @@ from typing import Optional
 from py4j.java_gateway import JavaObject
 from pyspark.sql import DataFrameReader, DataFrame
 
-from gresearch.spark import _to_seq
+from gresearch.spark import _jvm, _to_seq
 
 
 def _jreader(reader: DataFrameReader) -> JavaObject:
     jvm = reader._spark._jvm
-    return jvm.uk.co.gresearch.spark.parquet.__getattr__("package$").__getattr__("MODULE$").ExtendedDataFrameReader(reader._jreader)
+    return _jvm(jvm).uk.co.gresearch.spark.parquet.__getattr__("package$").__getattr__("MODULE$").ExtendedDataFrameReader(reader._jreader)
 
 
 def parquet_metadata(self: DataFrameReader, *paths: str, parallelism: Optional[int] = None) -> DataFrame:


### PR DESCRIPTION
Provides a meaningful error message when user accesses a spark extension function in Python that requires the Java / Scala package:

    RuntimeError: Java / Scala package not found! You need to add the spark-extension package to your PySpark environment: https://github.com/G-Research/spark-extension#python

Before, the error was:

    TypeError: 'JavaPackage' object is not callable

Improves #242