### PR TITLE
CI cache improvements

### DIFF
--- a/.github/actions/build-whl/action.yml
+++ b/.github/actions/build-whl/action.yml
@@ -53,16 +53,6 @@ runs:
       java-version: ${{ inputs.java-compat-version }}
       distribution: 'zulu'
 
-  - name: Restore Pip packages cache
-    if: github.event_name != 'schedule'
-    uses: actions/cache/restore@v4
-    with:
-      path: ~/.cache/pip
-      key: ${{ runner.os }}-pip-whl-${{ inputs.python-version }}-${{ hashFiles(format('python/requirements-{0}_{1}.txt', inputs.spark-compat-version, inputs.scala-compat-version)) }}
-      restore-keys:
-        ${{ runner.os }}-pip-whl-${{ inputs.python-version }}-${{ hashFiles(format('python/requirements-{0}_{1}.txt', inputs.spark-compat-version, inputs.scala-compat-version)) }}
-        ${{ runner.os }}-pip-whl-${{ inputs.python-version }}-
-
   - name: Setup Python
     uses: actions/setup-python@v5
     with:
@@ -85,13 +75,6 @@ runs:
       pip install python/dist/*.whl
       python test-release.py
     shell: bash
-
-  - name: Save Pip packages cache
-    if: github.event_name != 'schedule' && github.ref == 'refs/heads/master'
-    uses: actions/cache/save@v4
-    with:
-      path: ~/.cache/pip
-      key: ${{ runner.os }}-pip-whl-${{ inputs.python-version }}-${{ hashFiles(format('python/requirements-{0}_{1}.txt', inputs.spark-compat-version, inputs.scala-compat-version)) }}-${{ github.run_id }}
 
   - name: Upload whl
     uses: actions/upload-artifact@v4

--- a/.github/actions/check-compat/action.yml
+++ b/.github/actions/check-compat/action.yml
@@ -39,10 +39,10 @@ runs:
     uses: actions/cache/restore@v4
     with:
       path: ~/.m2/repository
-      key: ${{ runner.os }}-mvn-check-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}
+      key: ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}
       restore-keys:
-        ${{ runner.os }}-mvn-check-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}
-        ${{ runner.os }}-mvn-check-${{ inputs.spark-version }}-${{ inputs.scala-version }}-
+        ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}
+        ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-
 
   - name: Setup JDK 1.8
     uses: actions/setup-java@v4
@@ -76,13 +76,6 @@ runs:
       ls -lah ~/.m2/repository/uk/co/gresearch/spark/spark-extension_${{ inputs.scala-compat-version }}/${{ inputs.package-version }}-${{ inputs.spark-compat-version }}/spark-extension_${{ inputs.scala-compat-version }}-${{ inputs.package-version }}-${{ inputs.spark-compat-version }}.jar target/spark-extension*.jar
       japi-compliance-checker ~/.m2/repository/uk/co/gresearch/spark/spark-extension_${{ inputs.scala-compat-version }}/${{ inputs.package-version }}-${{ inputs.spark-compat-version }}/spark-extension_${{ inputs.scala-compat-version }}-${{ inputs.package-version }}-${{ inputs.spark-compat-version }}.jar target/spark-extension*.jar
     shell: bash
-
-  - name: Save Maven packages cache
-    if: github.event_name != 'schedule' && github.ref == 'refs/heads/master'
-    uses: actions/cache/save@v4
-    with:
-      path: ~/.m2/repository
-      key: ${{ runner.os }}-mvn-check-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}-${{ github.run_id }}
 
   - name: Upload Report
     uses: actions/upload-artifact@v4

--- a/.github/actions/prime-caches/action.yml
+++ b/.github/actions/prime-caches/action.yml
@@ -1,6 +1,6 @@
-name: 'Build'
+name: 'Prime caches'
 author: 'EnricoMi'
-description: 'A GitHub Action that builds spark-extension'
+description: 'A GitHub Action that primes caches'
 
 inputs:
   spark-version:
@@ -31,16 +31,6 @@ runs:
       git diff
     shell: bash
 
-  - name: Restore Maven packages cache
-    if: github.event_name != 'schedule'
-    uses: actions/cache/restore@v4
-    with:
-      path: ~/.m2/repository
-      key: ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}
-      restore-keys:
-        ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}
-        ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-
-
   - name: Setup JDK ${{ inputs.java-compat-version }}
     uses: actions/setup-java@v4
     with:
@@ -56,16 +46,27 @@ runs:
       mvn --batch-mode install -Dspotless.check.skip -DskipTests -Dmaven.test.skip=true -Dgpg.skip
     shell: bash
 
-  - name: Upload Binaries
-    uses: actions/upload-artifact@v4
+  - name: Save Maven packages cache
+    uses: actions/cache/save@v4
     with:
-      name: Binaries-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
-      path: |
-        *
-        !.*
-        !target/*-javadoc.jar
-        !target/*-sources.jar
-        !target/site
+      path: ~/.m2/repository
+      key: ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}-${{ github.run_id }}
+
+  - name: Setup Spark Binaries
+    if: ( ! contains(inputs.spark-version, '-SNAPSHOT') )
+    env:
+      SPARK_PACKAGE: spark-${{ inputs.spark-version }}/spark-${{ inputs.spark-version }}-bin-hadoop${{ inputs.hadoop-version }}${{ inputs.scala-compat-version == '2.13' && '-scala2.13' || '' }}.tgz
+    run: |
+      wget --progress=dot:giga "https://www.apache.org/dyn/closer.lua/spark/${SPARK_PACKAGE}?action=download" -O - | tar -xzC "${{ runner.temp }}"
+      archive=$(basename "${SPARK_PACKAGE}") bash -c "mv -v "${{ runner.temp }}/\${archive/%.tgz/}" ~/spark"
+    shell: bash
+
+  - name: Save Spark Binaries cache
+    if: ( ! contains(inputs.spark-version, '-SNAPSHOT') )
+    uses: actions/cache/save@v4
+    with:
+      path: ~/spark
+      key: ${{ runner.os }}-spark-binaries-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}-${{ github.run_id }}
 
 branding:
   icon: 'check-circle'

--- a/.github/actions/test-jvm/action.yml
+++ b/.github/actions/test-jvm/action.yml
@@ -93,20 +93,6 @@ runs:
     run: mvn --batch-mode surefire-report:report-only
     shell: bash
 
-  - name: Save Spark Binaries cache
-    if: github.event_name != 'schedule' && github.ref == 'refs/heads/master' && ! contains(inputs.spark-version, '-SNAPSHOT')
-    uses: actions/cache/save@v4
-    with:
-      path: ~/spark
-      key: ${{ runner.os }}-spark-binaries-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}-${{ github.run_id }}
-
-  - name: Save Maven packages cache
-    if: github.event_name != 'schedule' && github.ref == 'refs/heads/master'
-    uses: actions/cache/save@v4
-    with:
-      path: ~/.m2/repository
-      key: ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}-${{ github.run_id }}
-
   - name: Upload Unit Test Results
     if: always()
     uses: actions/upload-artifact@v4

--- a/.github/actions/test-jvm/action.yml
+++ b/.github/actions/test-jvm/action.yml
@@ -93,6 +93,20 @@ runs:
     run: mvn --batch-mode surefire-report:report-only
     shell: bash
 
+  - name: Save Spark Binaries cache
+    if: github.event_name != 'schedule' && github.ref == 'refs/heads/master' && ! contains(inputs.spark-version, '-SNAPSHOT')
+    uses: actions/cache/save@v4
+    with:
+      path: ~/spark
+      key: ${{ runner.os }}-spark-binaries-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}-${{ github.run_id }}
+
+  - name: Save Maven packages cache
+    if: github.event_name != 'schedule' && github.ref == 'refs/heads/master'
+    uses: actions/cache/save@v4
+    with:
+      path: ~/.m2/repository
+      key: ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}-${{ github.run_id }}
+
   - name: Upload Unit Test Results
     if: always()
     uses: actions/upload-artifact@v4

--- a/.github/actions/test-python/action.yml
+++ b/.github/actions/test-python/action.yml
@@ -81,18 +81,6 @@ runs:
       java-version: '8'
       distribution: 'zulu'
 
-  - name: Restore Pip packages cache
-    if: github.event_name != 'schedule'
-    uses: actions/cache/restore@v4
-    with:
-      path: ~/.cache/pip
-      key: ${{ runner.os }}-pip-test-${{ inputs.python-version }}-${{ hashFiles(format('python/requirements-{0}_{1}.txt', inputs.spark-compat-version, inputs.scala-compat-version)) }}
-      restore-keys:
-        ${{ runner.os }}-pip-test-${{ inputs.python-version }}-${{ hashFiles(format('python/requirements-{0}_{1}.txt', inputs.spark-compat-version, inputs.scala-compat-version)) }}
-        ${{ runner.os }}-pip-whl-${{ inputs.python-version }}-${{ hashFiles(format('python/requirements-{0}_{1}.txt', inputs.spark-compat-version, inputs.scala-compat-version)) }}
-        ${{ runner.os }}-pip-test-${{ inputs.python-version }}-
-        ${{ runner.os }}-pip-whl-${{ inputs.python-version }}-
-
   - name: Setup Python
     uses: actions/setup-python@v5
     with:
@@ -205,13 +193,6 @@ runs:
     run: |
       $SPARK_HOME/bin/spark-shell --packages uk.co.gresearch.spark:spark-extension_${{ inputs.scala-compat-version }}:$SPARK_EXTENSION_VERSION < test-release.scala
     shell: bash
-
-  - name: Save Pip packages cache
-    if: github.event_name != 'schedule' && github.ref == 'refs/heads/master'
-    uses: actions/cache/save@v4
-    with:
-      path: ~/.cache/pip
-      key: ${{ runner.os }}-pip-test-${{ inputs.python-version }}-${{ hashFiles(format('python/requirements-{0}_{1}.txt', inputs.spark-compat-version, inputs.scala-compat-version)) }}-${{ github.run_id }}}
 
   - name: Upload Test Results
     if: always()

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,14 +14,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Restore Maven packages cache
-        if: github.event_name != 'merge_group'
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-mvn-lint-${{ hashFiles('pom.xml') }}
-          restore-key: ${{ runner.os }}-mvn-lint-${{ hashFiles('pom.xml') }}
-
       - name: Setup JDK ${{ inputs.java-compat-version }}
         uses: actions/setup-java@v4
         with:
@@ -40,13 +32,6 @@ jobs:
           mvn --batch-mode --update-snapshots spotless:apply
           git diff
         shell: bash
-
-      - name: Save Maven packages cache
-        if: github.event_name != 'merge_group' && github.ref == 'refs/heads/master'
-        uses: actions/cache/save@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-mvn-lint-${{ hashFiles('pom.xml') }}-${{ github.run_id }}
 
   config:
     name: Configure compat

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,12 +14,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache Maven packages
+      - name: Restore Maven packages cache
         if: github.event_name != 'merge_group'
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-mvn-lint-${{ hashFiles('pom.xml') }}
+          restore-key: ${{ runner.os }}-mvn-lint-${{ hashFiles('pom.xml') }}
 
       - name: Setup JDK ${{ inputs.java-compat-version }}
         uses: actions/setup-java@v4
@@ -39,6 +40,13 @@ jobs:
           mvn --batch-mode --update-snapshots spotless:apply
           git diff
         shell: bash
+
+      - name: Save Maven packages cache
+        if: github.event_name != 'merge_group' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-mvn-lint-${{ hashFiles('pom.xml') }}-${{ github.run_id }}
 
   config:
     name: Configure compat

--- a/.github/workflows/prime-caches.yml
+++ b/.github/workflows/prime-caches.yml
@@ -1,16 +1,16 @@
-name: Test JVM
+name: Prime caches
 
 on:
   workflow_call:
 
 jobs:
   test:
-    name: Test (Spark ${{ matrix.spark-compat-version }}.${{ matrix.spark-patch-version }} Scala ${{ matrix.scala-version }})
+    name: Spark ${{ matrix.spark-compat-version }}.${{ matrix.spark-patch-version }} Scala ${{ matrix.scala-version }}
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
-      # keep in-sync with .github/workflows/prime-caches.yml
+      # keep in-sync with .github/workflows/test-jvm.yml
       matrix:
         scala-compat-version: ['2.12', '2.13']
         spark-compat-version: ['3.2', '3.3', '3.4', '3.5']
@@ -80,9 +80,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Test
-        uses: ./.github/actions/test-jvm
-        env:
-          CI_SLOW_TESTS: 1
+        uses: ./.github/actions/prime-caches
         with:
           spark-version: ${{ matrix.spark-compat-version }}.${{ matrix.spark-patch-version }}
           scala-version: ${{ matrix.scala-version }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -125,20 +125,21 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Cache Maven packages
+      - name: Restore Maven packages cache
         id: cache-maven
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-mvn-build-${{ matrix.params.spark-version }}-${{ matrix.params.scala-version }}-${{ hashFiles('pom.xml') }}
           restore-keys: ${{ runner.os }}-mvn-build-${{ matrix.params.spark-version }}-${{ matrix.params.scala-version }}-
       
-      - name: Cache Pip packages
+      - name: Restore Pip packages cache
         id: cache-pip
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-whl-${{ env.PYTHON_VERSION }}-${{ matrix.params.spark-version }}
+          restore-key: ${{ runner.os }}-pip-whl-${{ env.PYTHON_VERSION }}-${{ matrix.params.spark-version }}
 
       - name: Publish maven artifacts
         id: publish-maven

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -133,14 +133,6 @@ jobs:
           key: ${{ runner.os }}-mvn-build-${{ matrix.params.spark-version }}-${{ matrix.params.scala-version }}-${{ hashFiles('pom.xml') }}
           restore-keys: ${{ runner.os }}-mvn-build-${{ matrix.params.spark-version }}-${{ matrix.params.scala-version }}-
       
-      - name: Restore Pip packages cache
-        id: cache-pip
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-whl-${{ env.PYTHON_VERSION }}-${{ matrix.params.spark-version }}
-          restore-key: ${{ runner.os }}-pip-whl-${{ env.PYTHON_VERSION }}-${{ matrix.params.spark-version }}
-
       - name: Publish maven artifacts
         id: publish-maven
         run: |

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -57,17 +57,17 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Cache Maven packages
+      - name: Restore Maven packages cache
         id: cache-maven
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-mvn-build-${{ matrix.params.spark-version }}-${{ matrix.params.scala-version }}-${{ hashFiles('pom.xml') }}
           restore-keys: ${{ runner.os }}-mvn-build-${{ matrix.params.spark-version }}-${{ matrix.params.scala-version }}-
       
-      - name: Cache Pip packages
+      - name: Restore Pip packages cache
         id: cache-pip
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-whl-${{ env.PYTHON_VERSION }}-${{ matrix.params.spark-version }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -65,13 +65,6 @@ jobs:
           key: ${{ runner.os }}-mvn-build-${{ matrix.params.spark-version }}-${{ matrix.params.scala-version }}-${{ hashFiles('pom.xml') }}
           restore-keys: ${{ runner.os }}-mvn-build-${{ matrix.params.spark-version }}-${{ matrix.params.scala-version }}-
       
-      - name: Restore Pip packages cache
-        id: cache-pip
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-whl-${{ env.PYTHON_VERSION }}-${{ matrix.params.spark-version }}
-
       - name: Check if this is a SNAPSHOT version
         id: check-snapshot
         run: |


### PR DESCRIPTION
Moves populating caches into `Prime Caches` workflow. Run this on `master` to prepare caches. Any branch will then use those caches. Caching Spark binaries brings most performance benefits.