### PR TITLE
No need to run CI on push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: '0 8 */10 * *'
   push:
-    branches:
-      - master
     tags:
       - '*'
   merge_group:


### PR DESCRIPTION
We merge into master only via merge_group, so we have run CI on the master commits already.