### PR TITLE
Improve `publish-snapshot.yml`

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -80,8 +80,14 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE}}
 
+      - name: Prepare PyPi package to test release
+        if: ${{ matrix.params.scala-version }} == 2.12*
+        run: |
+          # Build whl
+          ./build-whl.sh
+
       - name: Test release
         id: test-package
         run: |
-          # Test the release
+          # Test the release (needs whl)
           ./test-release.sh

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Maven Central Repository
+      - name: Set up JDK and publish to Maven Central
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12  # v4.7.0
         with:
           java-version: '8'

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -13,10 +13,9 @@ jobs:
     name: Release snapshot Spark:${{ matrix.params.spark-version }} - Scala:${{ matrix.params.scala-version }}
     if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
-    environment: snapshot # secret GPG_PRIVATE_KEY is protected 
-    permissions:
-      contents: write # required to push to a branch
-      id-token: write # required for PiPy publish
+    # secrets are provided by environment
+    environment: snapshot
+    permissions: {}
     strategy:
       fail-fast: false
       matrix:
@@ -36,14 +35,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 8
-        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12  # 4.7.0
-        with:
-          java-version: '8'
-          distribution: 'corretto'
-
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12  # 4.7.0
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12  # v4.7.0
         with:
           java-version: '8'
           distribution: 'corretto'
@@ -81,18 +74,11 @@ jobs:
         id: snapshot
         run: |
           ./set-version.sh ${{ matrix.params.spark-version }} ${{ matrix.params.scala-version }}
-          mvn clean deploy -Dsign
+          mvn clean deploy -Dsign -Dspotless.check.skip -DskipTests -Dmaven.test.skip=true
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE}}
-
-      - name: Prepare PyPi package
-        id: prepare-pypi-package
-        if: ${{ matrix.params.scala-version }} == 2.12*
-        run: |
-          echo "Scala version starts with '2.12'"
-          ./build-whl.sh
 
       - name: Test release
         id: test-package


### PR DESCRIPTION
- no permissions needed
- setting up JDK once is sufficient
- no need to run tests and spotless, that has been done in CI
- clarify that we build whl for testing only, not published to PyPi