### PR TITLE
Test and fix Python without installed dependencies

### DIFF
--- a/.github/actions/test-jvm/action.yml
+++ b/.github/actions/test-jvm/action.yml
@@ -90,19 +90,6 @@ runs:
       echo "::endgroup::"
     shell: bash
 
-  - name: Diff App test
-    if: ( ! contains(inputs.spark-version, '-SNAPSHOT') )
-    run: |
-      # Diff App test
-      echo "::group::spark-submit"
-      $SPARK_HOME/bin/spark-submit --packages com.github.scopt:scopt_${{ inputs.scala-compat-version }}:4.1.0 target/spark-extension_*.jar --format parquet --id id src/test/files/test.parquet/file1.parquet src/test/files/test.parquet/file2.parquet diff.parquet
-      echo "::endgroup::"
-
-      echo "::group::spark-shell"
-      $SPARK_HOME/bin/spark-shell <<< 'val df = spark.read.parquet("diff.parquet").orderBy($"id").groupBy($"diff").count; df.show; if (df.count != 2) sys.exit(1)'
-      echo "::endgroup::"
-    shell: bash
-
   - name: Generate Unit Test Report
     if: failure()
     run: |

--- a/.github/actions/test-python/action.yml
+++ b/.github/actions/test-python/action.yml
@@ -97,6 +97,35 @@ runs:
     with:
       python-version: ${{ inputs.python-version }}
 
+  - name: Install Spark Extension
+    run: |
+      # Install Spark Extension
+      echo "::group::mvn install"
+      mvn --batch-mode --update-snapshots install -Dspotless.check.skip -DskipTests -Dmaven.test.skip=true -Dgpg.skip
+      echo "::endgroup::"
+    shell: bash
+
+  # These release tests come first as they should work without spark-extensions dependnecies being installed
+  - name: Python Release Test
+    env:
+      SPARK_HOME: ${{ env.PYSPARK_HOME }}
+    run: |
+      # Python Release Test
+      echo "::group::spark-submit"
+      $SPARK_BIN_HOME/bin/spark-submit --packages uk.co.gresearch.spark:spark-extension_${{ inputs.scala-compat-version }}:$SPARK_EXTENSION_VERSION test-release.py
+      echo "::endgroup::"
+    shell: bash
+
+  - name: Scala Release Test
+    env:
+      SPARK_HOME: ${{ env.SPARK_BIN_HOME }}
+    run: |
+      # Scala Release Test
+      echo "::group::spark-shell"
+      $SPARK_BIN_HOME/bin/spark-shell --packages uk.co.gresearch.spark:spark-extension_${{ inputs.scala-compat-version }}:$SPARK_EXTENSION_VERSION < test-release.scala
+      echo "::endgroup::"
+    shell: bash
+
   - name: Install Python dependencies
     run: |
       # Install Python dependencies
@@ -140,14 +169,6 @@ runs:
       PYTHONPATH: python/test
     run: |
       .pytest-venv/bin/python -m pytest python/test --junit-xml test-results/pytest-$(date +%s.%N)-$RANDOM.xml
-    shell: bash
-
-  - name: Install Spark Extension
-    run: |
-      # Install Spark Extension
-      echo "::group::mvn install"
-      mvn --batch-mode --update-snapshots install -Dspotless.check.skip -DskipTests -Dmaven.test.skip=true -Dgpg.skip
-      echo "::endgroup::"
     shell: bash
 
   - name: Start Spark Connect
@@ -236,26 +257,6 @@ runs:
         echo "::endgroup::"
       done < tests
       if [[ "$state" == "fail" ]]; then exit 1; fi
-    shell: bash
-
-  - name: Python Release Test
-    env:
-      SPARK_HOME: ${{ env.PYSPARK_HOME }}
-    run: |
-      # Python Release Test
-      echo "::group::spark-submit"
-      $PYSPARK_BIN_HOME/bin/spark-submit --packages uk.co.gresearch.spark:spark-extension_${{ inputs.scala-compat-version }}:$SPARK_EXTENSION_VERSION test-release.py
-      echo "::endgroup::"
-    shell: bash
-
-  - name: Scala Release Test
-    env:
-      SPARK_HOME: ${{ env.SPARK_BIN_HOME }}
-    run: |
-      # Scala Release Test
-      echo "::group::spark-shell"
-      $SPARK_BIN_HOME/bin/spark-shell --packages uk.co.gresearch.spark:spark-extension_${{ inputs.scala-compat-version }}:$SPARK_EXTENSION_VERSION < test-release.scala
-      echo "::endgroup::"
     shell: bash
 
   - name: Upload Test Results

--- a/.github/actions/test-python/action.yml
+++ b/.github/actions/test-python/action.yml
@@ -97,35 +97,6 @@ runs:
     with:
       python-version: ${{ inputs.python-version }}
 
-  - name: Install Spark Extension
-    run: |
-      # Install Spark Extension
-      echo "::group::mvn install"
-      mvn --batch-mode --update-snapshots install -Dspotless.check.skip -DskipTests -Dmaven.test.skip=true -Dgpg.skip
-      echo "::endgroup::"
-    shell: bash
-
-  # These release tests come first as they should work without spark-extensions dependnecies being installed
-  - name: Python Release Test
-    env:
-      SPARK_HOME: ${{ env.PYSPARK_HOME }}
-    run: |
-      # Python Release Test
-      echo "::group::spark-submit"
-      $SPARK_BIN_HOME/bin/spark-submit --packages uk.co.gresearch.spark:spark-extension_${{ inputs.scala-compat-version }}:$SPARK_EXTENSION_VERSION test-release.py
-      echo "::endgroup::"
-    shell: bash
-
-  - name: Scala Release Test
-    env:
-      SPARK_HOME: ${{ env.SPARK_BIN_HOME }}
-    run: |
-      # Scala Release Test
-      echo "::group::spark-shell"
-      $SPARK_BIN_HOME/bin/spark-shell --packages uk.co.gresearch.spark:spark-extension_${{ inputs.scala-compat-version }}:$SPARK_EXTENSION_VERSION < test-release.scala
-      echo "::endgroup::"
-    shell: bash
-
   - name: Install Python dependencies
     run: |
       # Install Python dependencies
@@ -169,6 +140,14 @@ runs:
       PYTHONPATH: python/test
     run: |
       .pytest-venv/bin/python -m pytest python/test --junit-xml test-results/pytest-$(date +%s.%N)-$RANDOM.xml
+    shell: bash
+
+  - name: Install Spark Extension
+    run: |
+      # Install Spark Extension
+      echo "::group::mvn install"
+      mvn --batch-mode --update-snapshots install -Dspotless.check.skip -DskipTests -Dmaven.test.skip=true -Dgpg.skip
+      echo "::endgroup::"
     shell: bash
 
   - name: Start Spark Connect
@@ -239,26 +218,6 @@ runs:
       done
     shell: bash
 
-  - name: Python Integration Tests
-    env:
-      SPARK_HOME: ${{ env.PYSPARK_HOME }}
-      PYTHONPATH: python:python/test
-    run: |
-      # Python Integration Tests
-      source .pytest-venv/bin/activate
-      find python/test -name 'test*.py' > tests
-      while read test
-      do
-        echo "::group::spark-submit $test"
-        if ! $PYSPARK_BIN_HOME/bin/spark-submit --master "local[2]" --packages uk.co.gresearch.spark:spark-extension_${{ inputs.scala-compat-version }}:$SPARK_EXTENSION_VERSION "$test" test-results-submit
-        then
-          state="fail"
-        fi
-        echo "::endgroup::"
-      done < tests
-      if [[ "$state" == "fail" ]]; then exit 1; fi
-    shell: bash
-
   - name: Upload Test Results
     if: always()
     uses: actions/upload-artifact@v4
@@ -266,7 +225,6 @@ runs:
       name: Python Test Results (Spark ${{ inputs.spark-version }} Scala ${{ inputs.scala-version }} Python ${{ inputs.python-version }})
       path: |
         test-results/*.xml
-        test-results-submit/*.xml
         test-results-connect/*.xml
 
 branding:

--- a/.github/actions/test-release/action.yml
+++ b/.github/actions/test-release/action.yml
@@ -89,6 +89,22 @@ runs:
       java-version: ${{ inputs.java-compat-version }}
       distribution: 'zulu'
 
+  - name: Diff App test
+    env:
+      SPARK_HOME: ${{ env.SPARK_BIN_HOME }}
+    run: |
+      # Diff App test
+      echo "::group::spark-submit"
+      $SPARK_HOME/bin/spark-submit --packages com.github.scopt:scopt_${{ inputs.scala-compat-version }}:4.1.0 target/spark-extension_*.jar --format parquet --id id src/test/files/test.parquet/file1.parquet src/test/files/test.parquet/file2.parquet diff.parquet
+      echo
+      echo "::endgroup::"
+
+      echo "::group::spark-shell"
+      $SPARK_HOME/bin/spark-shell <<< 'val df = spark.read.parquet("diff.parquet").orderBy($"id").groupBy($"diff").count; df.show; if (df.count != 2) sys.exit(1)'
+      echo
+      echo "::endgroup::"
+    shell: bash
+
   - name: Install Spark Extension
     run: |
       # Install Spark Extension

--- a/.github/actions/test-release/action.yml
+++ b/.github/actions/test-release/action.yml
@@ -1,0 +1,186 @@
+name: 'Test Release'
+author: 'EnricoMi'
+description: 'A GitHub Action that tests spark-extension release'
+
+# pyspark is not available for snapshots or scala other than 2.12
+# we would have to compile spark from sources for this, not worth it
+# so this action only works with scala 2.12 and non-snapshot spark versions
+inputs:
+  spark-version:
+    description: Spark version, e.g. 3.4.0 or 4.0.0-preview1
+    required: true
+  scala-version:
+    description: Scala version, e.g. 2.12.15
+    required: true
+  spark-compat-version:
+    description: Spark compatibility version, e.g. 3.4
+    required: true
+  spark-archive-url:
+    description: The URL to download the Spark binary distribution
+    required: false
+  scala-compat-version:
+    description: Scala compatibility version, e.g. 2.12
+    required: true
+  java-compat-version:
+    description: Java compatibility version, e.g. 8
+    required: true
+  hadoop-version:
+    description: Hadoop version, e.g. 2.7 or 2
+    required: true
+  python-version:
+    description: Python version, e.g. 3.8
+    default: ''
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+  - name: Fetch Binaries Artifact
+    uses: actions/download-artifact@v4
+    with:
+      name: Binaries-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
+      path: .
+
+  - name: Set versions in pom.xml
+    run: |
+      ./set-version.sh ${{ inputs.spark-version }} ${{ inputs.scala-version }}
+      git diff
+
+      SPARK_EXTENSION_VERSION=$(grep --max-count=1 "<version>.*</version>" pom.xml | sed -E -e "s/\s*<[^>]+>//g")
+      echo "SPARK_EXTENSION_VERSION=$SPARK_EXTENSION_VERSION" | tee -a "$GITHUB_ENV"
+    shell: bash
+
+  - name: Restore Spark Binaries cache
+    if: github.event_name != 'schedule'
+    uses: actions/cache/restore@v4
+    with:
+      path: ~/spark
+      key: ${{ runner.os }}-spark-binaries-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}
+      restore-keys: |
+        ${{ runner.os }}-spark-binaries-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}
+
+  - name: Setup Spark Binaries
+    env:
+      SPARK_PACKAGE: spark-${{ inputs.spark-version }}/spark-${{ inputs.spark-version }}-bin-hadoop${{ inputs.hadoop-version }}${{ startsWith(inputs.spark-version, '3.') && inputs.scala-compat-version == '2.13' && '-scala2.13' || '' }}.tgz
+    run: |
+      # Setup Spark Binaries
+      if [[ ! -e ~/spark ]]
+      then
+        url="${{ inputs.spark-archive-url }}"
+        wget --progress=dot:giga "${url:-https://www.apache.org/dyn/closer.lua/spark/${SPARK_PACKAGE}?action=download}" -O - | tar -xzC "${{ runner.temp }}"
+        archive=$(basename "${SPARK_PACKAGE}") bash -c "mv -v "${{ runner.temp }}/\${archive/%.tgz/}" ~/spark"
+      fi
+      echo "SPARK_BIN_HOME=$(cd ~/spark; pwd)" >> $GITHUB_ENV
+    shell: bash
+
+  - name: Restore Maven packages cache
+    if: github.event_name != 'schedule'
+    uses: actions/cache/restore@v4
+    with:
+      path: ~/.m2/repository
+      key: ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}
+      restore-keys: |
+        ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}
+        ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-
+
+  - name: Setup JDK ${{ inputs.java-compat-version }}
+    uses: actions/setup-java@v4
+    with:
+      java-version: ${{ inputs.java-compat-version }}
+      distribution: 'zulu'
+
+  - name: Install Spark Extension
+    run: |
+      # Install Spark Extension
+      echo "::group::mvn install"
+      mvn --batch-mode --update-snapshots install -Dspotless.check.skip -DskipTests -Dmaven.test.skip=true -Dgpg.skip
+      echo "::endgroup::"
+    shell: bash
+
+  - name: Scala Release Test
+    env:
+      SPARK_HOME: ${{ env.SPARK_BIN_HOME }}
+    run: |
+      # Scala Release Test
+      echo "::group::spark-shell"
+      $SPARK_BIN_HOME/bin/spark-shell --packages uk.co.gresearch.spark:spark-extension_${{ inputs.scala-compat-version }}:$SPARK_EXTENSION_VERSION < test-release.scala
+      echo
+      echo "::endgroup::"
+    shell: bash
+
+  - name: Setup Python
+    uses: actions/setup-python@v5
+    if: inputs.python-version != ''
+    with:
+      python-version: ${{ inputs.python-version }}
+
+  - name: Python Release Test
+    if: inputs.python-version != ''
+    env:
+      SPARK_HOME: ${{ env.SPARK_BIN_HOME }}
+    run: |
+      # Python Release Test
+      echo "::group::spark-submit"
+      $SPARK_BIN_HOME/bin/spark-submit --packages uk.co.gresearch.spark:spark-extension_${{ inputs.scala-compat-version }}:$SPARK_EXTENSION_VERSION test-release.py
+      echo
+      echo "::endgroup::"
+    shell: bash
+
+  - name: Install Python dependencies
+    if: inputs.python-version != ''
+    run: |
+      # Install Python dependencies
+      echo "::group::pip install"
+      python -m venv .pytest-venv
+      .pytest-venv/bin/python -m pip install --upgrade pip
+      .pytest-venv/bin/pip install pypandoc
+      .pytest-venv/bin/pip install -e python/[test]
+      echo "::endgroup::"
+
+      PYSPARK_HOME=$(.pytest-venv/bin/python -c "import os; import pyspark; print(os.path.dirname(pyspark.__file__))")
+      PYSPARK_BIN_HOME="$(cd ".pytest-venv/"; pwd)"
+      PYSPARK_PYTHON="$PYSPARK_BIN_HOME/bin/python"
+      echo "PYSPARK_HOME=$PYSPARK_HOME" | tee -a "$GITHUB_ENV"
+      echo "PYSPARK_BIN_HOME=$PYSPARK_BIN_HOME" | tee -a "$GITHUB_ENV"
+      echo "PYSPARK_PYTHON=$PYSPARK_PYTHON" | tee -a "$GITHUB_ENV"
+    shell: bash
+
+  - name: PySpark Release Test
+    if: inputs.python-version != ''
+    run: |
+      .pytest-venv/bin/python3 test-release.py
+    shell: bash
+
+  - name: Python Integration Tests
+    if: inputs.python-version != ''
+    env:
+      SPARK_HOME: ${{ env.PYSPARK_HOME }}
+      PYTHONPATH: python:python/test
+    run: |
+      # Python Integration Tests
+      source .pytest-venv/bin/activate
+      find python/test -name 'test*.py' > tests
+      while read test
+      do
+        echo "::group::spark-submit $test"
+        if ! $PYSPARK_BIN_HOME/bin/spark-submit --master "local[2]" --packages uk.co.gresearch.spark:spark-extension_${{ inputs.scala-compat-version }}:$SPARK_EXTENSION_VERSION "$test" test-results-submit
+        then
+          state="fail"
+        fi
+        echo
+        echo "::endgroup::"
+      done < tests
+      if [[ "$state" == "fail" ]]; then exit 1; fi
+    shell: bash
+
+  - name: Upload Test Results
+    if: always() && inputs.python-version != ''
+    uses: actions/upload-artifact@v4
+    with:
+      name: Python Release Test Results (Spark ${{ inputs.spark-version }} Scala ${{ inputs.scala-version }} Python ${{ inputs.python-version }})
+      path: |
+        test-results-submit/*.xml
+
+branding:
+  icon: 'check-circle'
+  color: 'green'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
     name: "Test Snapshots"
     needs: build-snapshots
     uses: "./.github/workflows/test-snapshots.yml"
+  test-release:
+    name: "Test Release"
+    needs: build-jvm
+    uses: "./.github/workflows/test-release.yml"
 
   check:
     name: "Check"
@@ -58,18 +62,18 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     # the if clauses below have to reflect the number of jobs listed here
-    needs: [build-jvm, build-python, test-jvm, test-python]
+    needs: [build-jvm, build-python, test-jvm, test-python, test-release]
     env:
       RESULTS: ${{ join(needs.*.result, ',') }}
 
     steps:
       - name: "Success"
         # we expect all required jobs to have success result
-        if: env.RESULTS == 'success,success,success,success'
+        if: env.RESULTS == 'success,success,success,success,success'
         run: true
         shell: bash
       - name: "Failure"
         # we expect all required jobs to have success result, fail otherwise
-        if: env.RESULTS != 'success,success,success,success'
+        if: env.RESULTS != 'success,success,success,success,success'
         run: false
         shell: bash

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,0 +1,105 @@
+name: Test release
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    name: Test Release Spark ${{ matrix.spark-version }} Scala ${{ matrix.scala-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - spark-compat-version: '3.0'
+            spark-version: '3.0.3'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.10'
+            java-compat-version: '8'
+            hadoop-version: '2.7'
+            python-version: '3.8'
+          - spark-compat-version: '3.1'
+            spark-version: '3.1.3'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.10'
+            java-compat-version: '8'
+            hadoop-version: '2.7'
+            python-version: '3.8'
+          - spark-compat-version: '3.2'
+            spark-version: '3.2.4'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.15'
+            java-compat-version: '8'
+            hadoop-version: '2.7'
+            python-version: '3.9'
+          - spark-compat-version: '3.3'
+            spark-version: '3.3.4'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.15'
+            java-compat-version: '8'
+            hadoop-version: '3'
+            python-version: '3.10'
+          - spark-compat-version: '3.4'
+            spark-version: '3.4.4'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.17'
+            java-compat-version: '8'
+            hadoop-version: '3'
+            python-version: '3.11'
+          - spark-compat-version: '3.5'
+            spark-version: '3.5.6'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.18'
+            java-compat-version: '8'
+            hadoop-version: '3'
+            python-version: '3.11'
+
+          - spark-compat-version: '3.2'
+            spark-version: '3.2.4'
+            scala-compat-version: '2.13'
+            scala-version: '2.13.5'
+            java-compat-version: '8'
+            hadoop-version: '3.2'
+          - spark-compat-version: '3.3'
+            spark-version: '3.3.4'
+            scala-compat-version: '2.13'
+            scala-version: '2.13.8'
+            java-compat-version: '8'
+            hadoop-version: '3'
+          - spark-compat-version: '3.4'
+            spark-version: '3.4.4'
+            scala-compat-version: '2.13'
+            scala-version: '2.13.8'
+            java-compat-version: '8'
+            hadoop-version: '3'
+          - spark-compat-version: '3.5'
+            spark-version: '3.5.6'
+            scala-compat-version: '2.13'
+            scala-version: '2.13.8'
+            java-compat-version: '8'
+            hadoop-version: '3'
+          - spark-compat-version: '4.0'
+            spark-version: '4.0.0'
+            scala-compat-version: '2.13'
+            scala-version: '2.13.16'
+            java-compat-version: '17'
+            hadoop-version: '3'
+            python-version: '3.13'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Test
+        uses: ./.github/actions/test-release
+        with:
+          spark-version: ${{ matrix.spark-version }}
+          scala-version: ${{ matrix.scala-version }}
+          spark-compat-version: ${{ matrix.spark-compat-version }}
+          spark-archive-url: ${{ matrix.spark-archive-url }}
+          scala-compat-version: ${{ matrix.scala-compat-version }}
+          java-compat-version: ${{ matrix.java-compat-version }}
+          hadoop-version: ${{ matrix.hadoop-version }}
+          python-version: ${{ matrix.python-version }}
+

--- a/python/gresearch/spark/diff/__init__.py
+++ b/python/gresearch/spark/diff/__init__.py
@@ -16,7 +16,6 @@ from dataclasses import dataclass
 from enum import Enum
 from functools import reduce
 from typing import Optional, Dict, Mapping, Any, Callable, List, Tuple, Union, Iterable, overload
-from typing_extensions import deprecated
 
 from py4j.java_gateway import JavaObject, JVMView
 from pyspark.sql import DataFrame, Column
@@ -27,6 +26,30 @@ from gresearch.spark import _get_jvm, _to_seq, _to_map, backticks, distinct_pref
     handle_configured_case_sensitivity, list_contains_case_sensitivity, list_filter_case_sensitivity, list_diff_case_sensitivity, \
     has_connect, _is_dataframe
 from gresearch.spark.diff.comparator import DiffComparator, DiffComparators, DefaultDiffComparator
+
+
+try:
+    # There is a chance users use the Python code contained in the jvm package with Spark
+    # without ever pip installing the whl package and thus lacking dependencies like this
+    #from typing_extensions import deprecated
+    raise ImportError()
+except ImportError:
+    from typing import TypeVar
+
+    _T = TypeVar("_T")
+
+    class deprecated:
+        def __init__(self, msg: str) -> None:
+            self.msg = msg
+
+        def __call__(self, func: _T) -> _T:
+            import warnings
+
+            def deprecated_func(*args, **kwargs):
+                warnings.warn(self.msg, DeprecationWarning, stacklevel=2)
+                return func(*args, **kwargs)
+
+            return deprecated_func
 
 
 class DiffMode(Enum):


### PR DESCRIPTION
The spark-extension Python code can be run without pip installing the whl file (via `--packages`), thus without installing dependencies.

This tests and fixes this situation.