### PR TITLE
ci: bump GitHub Actions to node24-compatible versions

### DIFF
--- a/.github/actions/build-whl/action.yml
+++ b/.github/actions/build-whl/action.yml
@@ -26,7 +26,7 @@ runs:
   using: 'composite'
   steps:
   - name: Fetch Binaries Artifact
-    uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+    uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
     with:
       name: Binaries-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
       path: .
@@ -46,7 +46,7 @@ runs:
 
   - name: Restore Maven packages cache
     if: github.event_name != 'schedule'
-    uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+    uses: actions/cache/restore@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
     with:
       path: ~/.m2/repository
       key: ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}
@@ -55,7 +55,7 @@ runs:
         ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-
 
   - name: Setup JDK ${{ inputs.java-compat-version }}
-    uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+    uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
     with:
       java-version: ${{ inputs.java-compat-version }}
       distribution: 'zulu'
@@ -69,7 +69,7 @@ runs:
     shell: bash
 
   - name: Setup Python
-    uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+    uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
     with:
       python-version: ${{ inputs.python-version }}
 
@@ -101,7 +101,7 @@ runs:
     shell: bash
 
   - name: Upload whl
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+    uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
     with:
       name: Whl (Spark ${{ inputs.spark-compat-version }} Scala ${{ inputs.scala-compat-version }})
       path: |

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -33,7 +33,7 @@ runs:
 
   - name: Restore Maven packages cache
     if: github.event_name != 'schedule'
-    uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+    uses: actions/cache/restore@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
     with:
       path: ~/.m2/repository
       key: ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}
@@ -42,7 +42,7 @@ runs:
         ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-
 
   - name: Setup JDK ${{ inputs.java-compat-version }}
-    uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+    uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
     with:
       java-version: ${{ inputs.java-compat-version }}
       distribution: 'zulu'
@@ -64,7 +64,7 @@ runs:
     shell: bash
 
   - name: Upload Binaries
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+    uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
     with:
       name: Binaries-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
       path: |

--- a/.github/actions/check-compat/action.yml
+++ b/.github/actions/check-compat/action.yml
@@ -23,7 +23,7 @@ runs:
   using: 'composite'
   steps:
   - name: Fetch Binaries Artifact
-    uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+    uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
     with:
       name: Binaries-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
       path: .
@@ -36,7 +36,7 @@ runs:
 
   - name: Restore Maven packages cache
     if: github.event_name != 'schedule'
-    uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+    uses: actions/cache/restore@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
     with:
       path: ~/.m2/repository
       key: ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}
@@ -45,7 +45,7 @@ runs:
         ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-
 
   - name: Setup JDK 1.8
-    uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+    uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
     with:
       java-version: '8'
       distribution: 'zulu'
@@ -88,7 +88,7 @@ runs:
     shell: bash
 
   - name: Upload Report
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+    uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
     if: always() && steps.exists.outcome == 'success'
     with:
       name: Compat-Report-${{ inputs.spark-compat-version }}

--- a/.github/actions/prime-caches/action.yml
+++ b/.github/actions/prime-caches/action.yml
@@ -33,7 +33,7 @@ runs:
 
   - name: Check Maven packages cache
     id: mvn-build-cache
-    uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+    uses: actions/cache/restore@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
     with:
       lookup-only: true
       path: ~/.m2/repository
@@ -41,7 +41,7 @@ runs:
 
   - name: Check Spark Binaries cache
     id: spark-binaries-cache
-    uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+    uses: actions/cache/restore@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
     with:
       lookup-only: true
       path: ~/spark
@@ -63,7 +63,7 @@ runs:
 
   - name: Setup JDK ${{ inputs.java-compat-version }}
     if: env.prime-some-cache
-    uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+    uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
     with:
       java-version: ${{ inputs.java-compat-version }}
       distribution: 'zulu'
@@ -79,7 +79,7 @@ runs:
 
   - name: Save Maven packages cache
     if: env.prime-mvn-cache
-    uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+    uses: actions/cache/save@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
     with:
       path: ~/.m2/repository
       key: ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}-${{ github.run_id }}
@@ -95,7 +95,7 @@ runs:
 
   - name: Save Spark Binaries cache
     if: env.prime-spark-cache && ! contains(inputs.spark-version, '-SNAPSHOT')
-    uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+    uses: actions/cache/save@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
     with:
       path: ~/spark
       key: ${{ runner.os }}-spark-binaries-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}-${{ github.run_id }}

--- a/.github/actions/test-jvm/action.yml
+++ b/.github/actions/test-jvm/action.yml
@@ -29,7 +29,7 @@ runs:
   using: 'composite'
   steps:
   - name: Fetch Binaries Artifact
-    uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+    uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
     with:
       name: Binaries-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
       path: .
@@ -42,7 +42,7 @@ runs:
 
   - name: Restore Spark Binaries cache
     if: github.event_name != 'schedule' && ! contains(inputs.spark-version, '-SNAPSHOT')
-    uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+    uses: actions/cache/restore@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
     with:
       path: ~/spark
       key: ${{ runner.os }}-spark-binaries-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}
@@ -66,7 +66,7 @@ runs:
 
   - name: Restore Maven packages cache
     if: github.event_name != 'schedule'
-    uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+    uses: actions/cache/restore@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
     with:
       path: ~/.m2/repository
       key: ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}
@@ -75,7 +75,7 @@ runs:
         ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-
 
   - name: Setup JDK ${{ inputs.java-compat-version }}
-    uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+    uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
     with:
       java-version: ${{ inputs.java-compat-version }}
       distribution: 'zulu'
@@ -90,7 +90,7 @@ runs:
 
   - name: Upload Test Results
     if: always()
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+    uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
     with:
       name: JVM Test Results (Spark ${{ inputs.spark-version }} Scala ${{ inputs.scala-version }})
       path: |

--- a/.github/actions/test-python/action.yml
+++ b/.github/actions/test-python/action.yml
@@ -38,7 +38,7 @@ runs:
   using: 'composite'
   steps:
   - name: Fetch Binaries Artifact
-    uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+    uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
     with:
       name: Binaries-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
       path: .
@@ -61,7 +61,7 @@ runs:
 
   - name: Restore Spark Binaries cache
     if: github.event_name != 'schedule' && ( startsWith(inputs.spark-version, '3.') && inputs.scala-compat-version == '2.12' || startsWith(inputs.spark-version, '4.') ) && ! contains(inputs.spark-version, '-SNAPSHOT')
-    uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+    uses: actions/cache/restore@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
     with:
       path: ~/spark
       key: ${{ runner.os }}-spark-binaries-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}
@@ -85,7 +85,7 @@ runs:
 
   - name: Restore Maven packages cache
     if: github.event_name != 'schedule'
-    uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+    uses: actions/cache/restore@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
     with:
       path: ~/.m2/repository
       key: ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}
@@ -94,13 +94,13 @@ runs:
         ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-
 
   - name: Setup JDK ${{ inputs.java-compat-version }}
-    uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+    uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
     with:
       java-version: ${{ inputs.java-compat-version }}
       distribution: 'zulu'
 
   - name: Setup Python
-    uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+    uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
     with:
       python-version: ${{ inputs.python-version }}
 
@@ -228,7 +228,7 @@ runs:
 
   - name: Upload Test Results
     if: always()
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+    uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
     with:
       name: Python Test Results (Spark ${{ inputs.spark-version }} Scala ${{ inputs.scala-version }} Python ${{ inputs.python-version }})
       path: |

--- a/.github/actions/test-release/action.yml
+++ b/.github/actions/test-release/action.yml
@@ -36,7 +36,7 @@ runs:
   using: 'composite'
   steps:
   - name: Fetch Binaries Artifact
-    uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+    uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
     with:
       name: Binaries-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
       path: .
@@ -52,7 +52,7 @@ runs:
 
   - name: Restore Spark Binaries cache
     if: github.event_name != 'schedule'
-    uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+    uses: actions/cache/restore@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
     with:
       path: ~/spark
       key: ${{ runner.os }}-spark-binaries-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}
@@ -75,7 +75,7 @@ runs:
 
   - name: Restore Maven packages cache
     if: github.event_name != 'schedule'
-    uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+    uses: actions/cache/restore@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
     with:
       path: ~/.m2/repository
       key: ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-${{ hashFiles('pom.xml') }}
@@ -84,7 +84,7 @@ runs:
         ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-version }}-
 
   - name: Setup JDK ${{ inputs.java-compat-version }}
-    uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+    uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
     with:
       java-version: ${{ inputs.java-compat-version }}
       distribution: 'zulu'
@@ -133,7 +133,7 @@ runs:
     shell: bash
 
   - name: Setup Python
-    uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+    uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
     if: inputs.python-version != ''
     with:
       python-version: ${{ inputs.python-version }}
@@ -152,7 +152,7 @@ runs:
 
   - name: Fetch Whl Artifact
     if: inputs.python-version != ''
-    uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+    uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
     with:
       name: Whl (Spark ${{ inputs.spark-compat-version }} Scala ${{ inputs.scala-compat-version }})
       path: .
@@ -206,7 +206,7 @@ runs:
 
   - name: Upload Test Results
     if: always() && inputs.python-version != ''
-    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+    uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
     with:
       name: Python Release Test Results (Spark ${{ inputs.spark-version }} Scala ${{ inputs.scala-version }} Python ${{ inputs.python-version }})
       path: |

--- a/.github/workflows/build-jvm.yml
+++ b/.github/workflows/build-jvm.yml
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Build
         uses: ./.github/actions/build

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Build
         uses: ./.github/actions/build-whl

--- a/.github/workflows/build-snapshots.yml
+++ b/.github/workflows/build-snapshots.yml
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Build
         uses: ./.github/actions/build

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,12 +10,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
       - name: Setup JDK ${{ inputs.java-compat-version }}
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           java-version: '11'
           distribution: 'zulu'
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
@@ -99,7 +99,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Check
         uses: ./.github/actions/check-compat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: Event File
           path: ${{ github.event_path }}

--- a/.github/workflows/clear-caches.yaml
+++ b/.github/workflows/clear-caches.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clear caches
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const caches = await github.paginate(

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -18,7 +18,7 @@ jobs:
       is-snapshot: ${{ steps.versions.outputs.is-snapshot }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Create GitHub App token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -60,7 +60,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
@@ -164,7 +164,7 @@ jobs:
 
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ needs.get-version.outputs.release-tag }}
 
@@ -181,7 +181,7 @@ jobs:
           echo "release_notes_path=release-notes.txt" >> $GITHUB_OUTPUT
 
       - name: Publish GitHub release
-        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         id: github-release
         with:
           name: ${{ steps.release-notes.outputs.release_name }}

--- a/.github/workflows/prime-caches.yml
+++ b/.github/workflows/prime-caches.yml
@@ -149,7 +149,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Prime caches
         uses: ./.github/actions/prime-caches

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -36,7 +36,7 @@ jobs:
       is-snapshot: ${{ steps.versions.outputs.is-snapshot }}
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Get versions
         id: versions
@@ -92,10 +92,10 @@ jobs:
 
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up JDK and publish to Maven Central
-        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12  # v4.7.0
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           java-version: ${{ matrix.params.java-compat-version }}
           distribution: 'corretto'
@@ -110,7 +110,7 @@ jobs:
 
       - name: Restore Maven packages cache
         id: cache-maven
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache/restore@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-mvn-build-${{ matrix.params.spark-version }}-${{ matrix.params.scala-version }}-${{ hashFiles('pom.xml') }}
@@ -147,21 +147,21 @@ jobs:
 
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up JDK
-        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12  # v4.7.0
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           java-version: ${{ matrix.params.java-compat-version }}
           distribution: 'corretto'
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Restore Maven packages cache
         id: cache-maven
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache/restore@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-mvn-build-${{ matrix.params.spark-version }}-${{ matrix.params.scala-version }}-${{ hashFiles('pom.xml') }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Check if this is a SNAPSHOT version
         id: check
@@ -64,10 +64,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up JDK and publish to Maven Central
-        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12  # v4.7.0
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           java-version: ${{ matrix.params.java-compat-version }}
           distribution: 'corretto'
@@ -80,13 +80,13 @@ jobs:
       - name: Inspect GPG
         run: gpg -k
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Restore Maven packages cache
         id: cache-maven
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache/restore@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-mvn-build-${{ matrix.params.spark-version }}-${{ matrix.params.scala-version }}-${{ hashFiles('pom.xml') }}
@@ -111,7 +111,7 @@ jobs:
           ./build-whl.sh
 
       - name: Restore Spark Binaries cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache/restore@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
         with:
           path: ~/spark
           key: ${{ runner.os }}-spark-binaries-${{ matrix.params.spark-version }}-${{ matrix.params.scala-compat-version }}

--- a/.github/workflows/test-jvm.yml
+++ b/.github/workflows/test-jvm.yml
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Test
         uses: ./.github/actions/test-jvm

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -91,7 +91,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Test
         uses: ./.github/actions/test-python

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Test
         uses: ./.github/actions/test-release

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Download and Extract Artifacts
-        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe
+        uses: dawidd6/action-download-artifact@09b07ec687d10771279a426c79925ee415c12906 # v17
         with:
           run_id: ${{ github.event.workflow_run.id }}
           name: "^Event File$| Test Results "

--- a/.github/workflows/test-snapshots.yml
+++ b/.github/workflows/test-snapshots.yml
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Test
         uses: ./.github/actions/test-jvm


### PR DESCRIPTION
## Summary

Bumps all GitHub Actions references that declare `runs.using: node20` to their lowest published version that declares `runs.using: node24`, ahead of the GitHub-enforced cutover on 2026-06-02.

### Changes

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `34e11487` (v4) | `08c6903` (v5.0.0) |
| `actions/setup-java` | `3a4f6e1a` / `c1e32368` (v4.x) | `dded0888` (v5.0.0) |
| `actions/setup-python` | `a26af69b` (v5.x) | `e797f83b` (v6.0.0) |
| `actions/cache` | `0057852b` (v4.x) | `a7833574` (v5.0.0) |
| `actions/download-artifact` | `d3f86a10` (v4.x) | `37930b1c` (v7.0.0) |
| `actions/upload-artifact` | `ea165f8d` (v4.x) | `b7c566a7` (v6.0.0) |
| `actions/github-script` | `f28e40c7` (v7.x) | `ed597411` (v8.0.0) |
| `actions/create-github-app-token` | `fee1f7d6` (v2.x) | `f8d387b6` (v3.0.0) |
| `dawidd6/action-download-artifact` | `09f2f748` (v16.x) | `09b07ec6` (v17) |
| `ncipollo/release-action` | `2c591bcc` (v1.18.x) | `339a81892` (v1.21.0) |

Part of G-Research/gr-oss#1359.